### PR TITLE
Don't suffix match single class names

### DIFF
--- a/bazelfe-core/src/error_extraction/scala/mod.rs
+++ b/bazelfe-core/src/error_extraction/scala/mod.rs
@@ -151,6 +151,11 @@ pub fn extract_errors(input: &str) -> Vec<super::ActionRequest> {
                 super::ActionRequest::Prefix(r)
             }
         })
+    }).filter(|e| {
+        match e {
+            super::ActionRequest::Prefix(_) => true,
+            super::ActionRequest::Suffix(s) => s.suffix.chars().filter(|e| *e == '.').count() > 0,
+        }
     })
     .collect();
 


### PR DESCRIPTION
If someone starts using a class without the right import, even if we add the dependency it won't help much! 