### PR TITLE
Make the buildozer args generic over the enum

### DIFF
--- a/bazelfe-core/src/buildozer_driver/buildozer_driver_app.rs
+++ b/bazelfe-core/src/buildozer_driver/buildozer_driver_app.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 use std::error::Error;
 use std::path::PathBuf;
 
-use bazelfe_core::buildozer_driver::{from_binary_path, Buildozer};
+use bazelfe_core::buildozer_driver::{from_binary_path, BazelAttrTarget, Buildozer};
 
 #[derive(Parser, Debug)]
 #[clap(name = "basic")]
@@ -17,7 +17,10 @@ struct Opt {
 async fn main() -> Result<(), Box<dyn Error>> {
     let opt = Opt::parse();
     let buildozer = from_binary_path(&opt.buildozer_path);
-    let buildozer_resp = buildozer.print_deps(&opt.target_name).await.unwrap();
+    let buildozer_resp = buildozer
+        .print_attr(&BazelAttrTarget::Deps, &opt.target_name)
+        .await
+        .unwrap();
     println!("{:?}", buildozer_resp);
     Ok(())
 }

--- a/bazelfe-core/src/hydrated_stream_processors/process_bazel_failures/process_action_failure_error.rs
+++ b/bazelfe-core/src/hydrated_stream_processors/process_bazel_failures/process_action_failure_error.rs
@@ -1,6 +1,9 @@
 use lazy_static::lazy_static;
 
-use crate::{build_events::hydrated_stream, buildozer_driver::Buildozer};
+use crate::{
+    build_events::hydrated_stream,
+    buildozer_driver::{BazelAttrTarget, Buildozer},
+};
 use regex::Regex;
 use std::time::Instant;
 
@@ -73,7 +76,11 @@ async fn apply_candidates<T: Buildozer + Clone + Send + Sync + 'static>(
                     dependency_to_remove, target_to_operate_on
                 );
                 let buildozer_res = buildozer
-                    .remove_dependency(&target_to_operate_on, &dependency_to_remove)
+                    .remove_from(
+                        &BazelAttrTarget::Deps,
+                        &target_to_operate_on,
+                        &dependency_to_remove,
+                    )
                     .await;
                 match buildozer_res {
                     Ok(_) => {


### PR DESCRIPTION
Make this code generic, and for the case of a non-existant build file ensure we remove refs from runtime deps too