### PR TITLE
Migrate to latest deps and remove tarpc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,9 +91,52 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "axum"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47594e438a243791dba58124b6669561f5baa14cb12046641d8008bf035e5a25"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a671c9ae99531afdd5d3ee8340b8da547779430689947144c140fc74a740244"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+]
 
 [[package]]
 name = "base64"
@@ -120,7 +163,7 @@ dependencies = [
  "bytes",
  "clap",
  "crossbeam-channel",
- "crossterm 0.23.1",
+ "crossterm 0.23.2",
  "ctrlc",
  "dashmap",
  "dynfmt",
@@ -150,13 +193,12 @@ dependencies = [
  "sha2",
  "shellwords",
  "stdio-override",
- "tarpc",
  "tempfile",
  "thiserror",
  "tokio",
  "tokio-serde",
  "tokio-stream",
- "tokio-util 0.6.9",
+ "tokio-util",
  "toml",
  "tonic",
  "tower",
@@ -263,9 +305,9 @@ checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
 name = "cc"
-version = "1.0.72"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 dependencies = [
  "jobserver",
 ]
@@ -308,11 +350,20 @@ version = "3.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
 dependencies = [
- "heck 0.4.0",
+ "heck",
  "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8ad8cef104ac57b68b89df3208164d228503abbdce70f6880ffa3d970e7443a"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -338,9 +389,9 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
+checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
 dependencies = [
  "libc",
 ]
@@ -366,9 +417,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e5bed1f1c269533fa816a0a5492b3545209a205ca1a54842be180eb63a16a6"
+checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
 dependencies = [
  "cfg-if",
  "lazy_static",
@@ -392,14 +443,14 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.23.1"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1fd7173631a4e9e2ca8b32ae2fad58aab9843ea5aaf56642661937d87e28a3e"
+checksum = "a2102ea4f781910f8a5b98dd061f4c2023f479ce7bb1236330099ceb5a93cf17"
 dependencies = [
  "bitflags",
  "crossterm_winapi",
  "libc",
- "mio 0.7.14",
+ "mio 0.8.2",
  "parking_lot 0.12.0",
  "signal-hook",
  "signal-hook-mio",
@@ -479,9 +530,9 @@ dependencies = [
 
 [[package]]
 name = "educe"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f86b50932a01e7ec5c06160492ab660fb19b6bb2a7878030dd6cd68d21df9d4d"
+checksum = "c07b7cc9cd8c08d10db74fca3b20949b9b6199725c04a0cce6d543496098fcac"
 dependencies = [
  "enum-ordinalize",
  "proc-macro2",
@@ -517,14 +568,15 @@ dependencies = [
 
 [[package]]
 name = "enum-ordinalize"
-version = "3.1.10"
+version = "3.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b166c9e378360dd5a6666a9604bb4f54ae0cac39023ffbac425e917a2a04fef"
+checksum = "2170fc0efee383079a8bdd05d6ea2a184d2a0f07a1c1dcabdb2fd5e9f24bc36c"
 dependencies = [
  "num-bigint",
  "num-traits",
  "proc-macro2",
  "quote",
+ "rustc_version",
  "syn",
 ]
 
@@ -543,9 +595,9 @@ dependencies = [
 
 [[package]]
 name = "erased-serde"
-version = "0.3.18"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56047058e1ab118075ca22f9ecd737bcc961aa3566a3019cb71388afa280bd8a"
+checksum = "ad132dd8d0d0b546348d7d86cb3191aad14b34e5f979781fc005c80d4ac67ffd"
 dependencies = [
  "serde",
 ]
@@ -681,7 +733,6 @@ checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
 dependencies = [
  "futures-channel",
  "futures-core",
- "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -705,32 +756,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
 
 [[package]]
-name = "futures-executor"
-version = "0.3.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-io"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "futures-sink"
@@ -750,16 +779,11 @@ version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
- "futures-macro",
  "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
- "slab",
 ]
 
 [[package]]
@@ -774,14 +798,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
+checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.10.2+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -799,9 +823,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.13.25"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29229cc1b24c0e6062f6e742aa3e256492a5323365e5ed3413599f8a5eff7d6"
+checksum = "3826a6e0e2215d7a41c2bfc7c9244123969273f3476b939a226aac0ab56e9e3c"
 dependencies = [
  "bitflags",
  "libc",
@@ -825,9 +849,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.11"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9f1f717ddc7b2ba36df7e871fd88db79326551d3d6f1fc406fbfd28b582ff8e"
+checksum = "37a82c6d637fc9515a4694bbf1cb2457b79d81ce52b3108bdeea58b07dd34a57"
 dependencies = [
  "bytes",
  "fnv",
@@ -838,7 +862,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util 0.6.9",
+ "tokio-util",
  "tracing",
 ]
 
@@ -847,15 +871,6 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-
-[[package]]
-name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
 
 [[package]]
 name = "heck"
@@ -889,7 +904,7 @@ checksum = "31f4c6746584866f0feabcc69893c5b51beef3831656a968ed7ae254cdc4fd03"
 dependencies = [
  "bytes",
  "fnv",
- "itoa 1.0.1",
+ "itoa",
 ]
 
 [[package]]
@@ -904,10 +919,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "httparse"
-version = "1.5.1"
+name = "http-range-header"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
+checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
+
+[[package]]
+name = "httparse"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9100414882e15fb7feccb4897e5f0ff0ff1ca7d1a86a23208ada4d7a18e6c6c4"
 
 [[package]]
 name = "httpdate"
@@ -932,9 +953,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.16"
+version = "0.14.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7ec3e62bdc98a2f0393a5048e4c30ef659440ea6e0e572965103e72bd836f55"
+checksum = "b26ae0a80afebe130861d90abf98e3814a4f28a4c6ffeb5ab8ebb2be311e0ef2"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -945,7 +966,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 0.4.8",
+ "itoa",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -997,9 +1018,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
+checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -1042,12 +1063,6 @@ checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
 dependencies = [
  "either",
 ]
-
-[[package]]
-name = "itoa"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
@@ -1107,9 +1122,9 @@ checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.26+1.3.0"
+version = "0.13.2+1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e1c899248e606fbfe68dcb31d8b0176ebab833b103824af31bddf4b7457494"
+checksum = "3a42de9a51a5c12e00fc0e4ca6bc2ea43582fc6418488e8f615e905d886f258b"
 dependencies = [
  "cc",
  "libc",
@@ -1119,9 +1134,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.3"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de5435b8549c16d423ed0c03dbaafe57cf6c3344744f1242520d59c9d8ecec66"
+checksum = "6f35facd4a5673cb5a48822be2be1d4236c1c99cb4113cab7061ac720d5bf859"
 dependencies = [
  "cc",
  "libc",
@@ -1131,10 +1146,11 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
+checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
 dependencies = [
+ "autocfg",
  "scopeguard",
 ]
 
@@ -1154,6 +1170,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
+name = "matchit"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
+
+[[package]]
 name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1167,6 +1189,12 @@ checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "minimal-lexical"
@@ -1199,14 +1227,15 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba272f85fa0b41fc91872be579b3bbe0f56b792aa361a380eb669469f68dafb2"
+checksum = "52da4364ffb0e4fe33a9841a98a3f3014fb964045ce4f7a45a398243c8d6b0c9"
 dependencies = [
  "libc",
  "log",
  "miow",
  "ntapi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "winapi",
 ]
 
@@ -1276,16 +1305,16 @@ dependencies = [
  "inotify",
  "kqueue",
  "libc",
- "mio 0.8.0",
+ "mio 0.8.2",
  "walkdir",
  "winapi",
 ]
 
 [[package]]
 name = "ntapi"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
 dependencies = [
  "winapi",
 ]
@@ -1332,9 +1361,9 @@ dependencies = [
 
 [[package]]
 name = "num_threads"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97ba99ba6393e2c3734791401b66902d981cb03bf190af674ca69949b6d5fb15"
+checksum = "aba1801fb138d8e85e11d0fc70baf4fe1cdfffda7c6cd34a854905df588e5ed0"
 dependencies = [
  "libc",
 ]
@@ -1350,23 +1379,6 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-
-[[package]]
-name = "opentelemetry"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cf9b1c4e9a6c4de793c632496fa490bdc0e1eea73f0c91394f7b6990935d22"
-dependencies = [
- "async-trait",
- "crossbeam-channel",
- "futures",
- "js-sys",
- "lazy_static",
- "percent-encoding",
- "pin-project",
- "rand",
- "thiserror",
-]
 
 [[package]]
 name = "os_str_bytes"
@@ -1395,7 +1407,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.1",
+ "parking_lot_core 0.9.2",
 ]
 
 [[package]]
@@ -1414,9 +1426,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954"
+checksum = "995f667a6c822200b0433ac218e05582f0e2efa1b922a3fd2fbaadc5f87bab37"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1510,9 +1522,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
+checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "ppv-lite86"
@@ -1528,6 +1540,16 @@ checksum = "926d36b9553851b8b0005f1275891b392ee4d2d833852c417ed025477350fb9d"
 dependencies = [
  "env_logger",
  "log",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b83ec2d0af5c5c556257ff52c9f98934e243b9fd39604bfb2a9b75ec2e97f18"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -1565,9 +1587,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
+checksum = "1bd5316aa8f5c82add416dfbc25116b84b748a21153f512917e8143640a71bbd"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -1575,12 +1597,14 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
+checksum = "328f9f29b82409216decb172d81e936415d21245befa79cd34c3f29d87d1c50b"
 dependencies = [
  "bytes",
- "heck 0.3.3",
+ "cfg-if",
+ "cmake",
+ "heck",
  "itertools",
  "lazy_static",
  "log",
@@ -1595,9 +1619,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
+checksum = "df35198f0777b75e9ff669737c6da5136b59dba33cf5a010a6d1cc4d56defc6f"
 dependencies = [
  "anyhow",
  "itertools",
@@ -1608,9 +1632,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
+checksum = "926681c118ae6e512a3ccefd4abbe5521a14f4cc1e207356d4d00c0b7f2006fd"
 dependencies = [
  "bytes",
  "prost",
@@ -1624,9 +1648,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
+checksum = "632d02bff7f874a36f33ea8bb416cd484b90cc66c1194b1a1110d067a7013f58"
 dependencies = [
  "proc-macro2",
 ]
@@ -1663,9 +1687,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.10"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
 dependencies = [
  "bitflags",
 ]
@@ -1722,15 +1746,23 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.19.1"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
+checksum = "4fbfeb8d0ddb84706bc597a5574ab8912817c52a397f819e5b614e2265206921"
 dependencies = [
- "base64",
  "log",
  "ring",
  "sct",
  "webpki",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ee86d63972a7c661d1536fefe8c3c8407321c3df668891286de28abcd087360"
+dependencies = [
+ "base64",
 ]
 
 [[package]]
@@ -1762,9 +1794,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "sct"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
@@ -1772,9 +1804,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0486718e92ec9a68fbed73bb5ef687d71103b142595b406835649bebd33f72c7"
+checksum = "d65bd28f48be7196d222d95b9243287f48d27aca604e08497513019ff0502cc4"
 
 [[package]]
 name = "serde"
@@ -1802,7 +1834,7 @@ version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
 dependencies = [
- "itoa 1.0.1",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -1830,15 +1862,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sharded-slab"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
-dependencies = [
- "lazy_static",
-]
-
-[[package]]
 name = "shellwords"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1860,12 +1883,13 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-mio"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29fd5867f1c4f2c5be079aee7a2adf1152ebb04a4bc4d341f504b7dece607ed4"
+checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
 dependencies = [
  "libc",
  "mio 0.7.14",
+ "mio 0.8.2",
  "signal-hook",
 ]
 
@@ -1880,9 +1904,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
+checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
 
 [[package]]
 name = "smallvec"
@@ -1916,12 +1940,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "stdio-override"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1944,9 +1962,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.86"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
+checksum = "704df27628939572cd88d33f171cd6f896f4eaca85252c6e0a72d8d8287ee86f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1954,10 +1972,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "sysinfo"
-version = "0.23.1"
+name = "sync_wrapper"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb29fc86b56b6d432ecdbbff2e5726aeaa69bf1bb48ddd994432b60d8bccd01"
+checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
+
+[[package]]
+name = "sysinfo"
+version = "0.23.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f3c0db8e08e06cfd352a043bd0143498fb7d42783a6e941da83b55464eb27d2"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",
@@ -1965,41 +1989,6 @@ dependencies = [
  "ntapi",
  "once_cell",
  "winapi",
-]
-
-[[package]]
-name = "tarpc"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b85d0a9369a919ba0db919b142a2b704cd207dfc676f7a43c2d105d0bc225487"
-dependencies = [
- "anyhow",
- "fnv",
- "futures",
- "humantime 2.1.0",
- "opentelemetry",
- "pin-project",
- "rand",
- "serde",
- "static_assertions",
- "tarpc-plugins",
- "thiserror",
- "tokio",
- "tokio-serde",
- "tokio-util 0.6.9",
- "tracing",
- "tracing-opentelemetry",
-]
-
-[[package]]
-name = "tarpc-plugins"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee42b4e559f17bce0385ebf511a7beb67d5cc33c12c96b7f4e9789919d9c10f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -2018,9 +2007,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
@@ -2062,11 +2051,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.7"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "004cbc98f30fa233c61a38bc77e96a9106e65c88f2d3bef182ae952027e5753d"
+checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
 dependencies = [
- "itoa 1.0.1",
+ "itoa",
  "libc",
  "num_threads",
  "time-macros",
@@ -2074,9 +2063,9 @@ dependencies = [
 
 [[package]]
 name = "time-macros"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25eb0ca3468fc0acc11828786797f6ef9aa1555e4a211a60d64cc8e4d1be47d6"
+checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
 
 [[package]]
 name = "tinyvec"
@@ -2102,7 +2091,7 @@ dependencies = [
  "bytes",
  "libc",
  "memchr",
- "mio 0.8.0",
+ "mio 0.8.2",
  "num_cpus",
  "once_cell",
  "parking_lot 0.12.0",
@@ -2136,9 +2125,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.22.0"
+version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
+checksum = "4151fda0cf2798550ad0b34bcfc9b9dcc2a9d2471c895c68f3a8818e54f2389e"
 dependencies = [
  "rustls",
  "tokio",
@@ -2173,32 +2162,17 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.9"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
+checksum = "0edfdeb067411dba2044da6d1cb2df793dd35add7888d73c16e3381ded401764"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-io",
  "futures-sink",
- "log",
- "pin-project-lite",
- "slab",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64910e1b9c1901aaf5375561e35b9c057d95ff41a44ede043a03e09279eabaf1"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "log",
  "pin-project-lite",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -2212,12 +2186,13 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.6.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff08f4649d10a70ffa3522ca559031285d8e421d727ac85c60825761818f5d0a"
+checksum = "30fb54bf1e446f44d870d260d99957e7d11fb9d0a0f5bd1a662ad1411cc103f9"
 dependencies = [
  "async-stream",
  "async-trait",
+ "axum",
  "base64",
  "bytes",
  "futures-core",
@@ -2231,10 +2206,11 @@ dependencies = [
  "pin-project",
  "prost",
  "prost-derive",
+ "rustls-pemfile",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
- "tokio-util 0.6.9",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
@@ -2244,10 +2220,11 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9403f1bafde247186684b230dc6f38b5cd514584e8bec1dd32514be4745fa757"
+checksum = "4d17087af5c80e5d5fc8ba9878e60258065a0a757e35efe7a05b7904bece1943"
 dependencies = [
+ "prettyplease",
  "proc-macro2",
  "prost-build",
  "quote",
@@ -2268,10 +2245,29 @@ dependencies = [
  "rand",
  "slab",
  "tokio",
- "tokio-util 0.7.0",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aba3f3efabf7fb41fae8534fc20a817013dd1c12cb45441efb6c82e6556b4cd8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-range-header",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -2288,9 +2284,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.30"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d8d93354fe2a8e50d5953f5ae2e47a3fc2ef03292e7ea46e3cc38f549525fb9"
+checksum = "4a1bdf54a7c28a2bbf701e1d2233f6c77f473486b94bee4f9678da5a148dca7f"
 dependencies = [
  "cfg-if",
  "log",
@@ -2301,9 +2297,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8276d9a4a3a558d7b7ad5303ad50b53d58264641b82914b7ada36bd762e7a716"
+checksum = "2e65ce065b4b5c53e73bb28912318cb8c9e9ad3921f1d669eb0e68b4c8143a2b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2312,12 +2308,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.22"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03cfcb51380632a72d3111cb8d3447a8d908e577d31beeac006f836383d29a23"
+checksum = "90442985ee2f57c9e1b548ee72ae842f4a9a20e3f417cc38dbc5dc684d9bb4ee"
 dependencies = [
  "lazy_static",
- "valuable",
 ]
 
 [[package]]
@@ -2328,29 +2323,6 @@ checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
  "pin-project",
  "tracing",
-]
-
-[[package]]
-name = "tracing-opentelemetry"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "599f388ecb26b28d9c1b2e4437ae019a7b336018b45ed911458cd9ebf91129f6"
-dependencies = [
- "opentelemetry",
- "tracing",
- "tracing-core",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
-dependencies = [
- "sharded-slab",
- "thread_local",
- "tracing-core",
 ]
 
 [[package]]
@@ -2436,12 +2408,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "valuable"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
-
-[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2497,6 +2463,12 @@ name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
@@ -2564,9 +2536,9 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.21.4"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
 dependencies = [
  "ring",
  "untrusted",
@@ -2574,9 +2546,9 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "4.2.4"
+version = "4.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a5a7e487e921cf220206864a94a89b6c6905bfc19f1057fa26a4cb360e5c1d2"
+checksum = "5c4fb54e6113b6a8772ee41c3404fb0301ac79604489467e0a9ce1f3e97c24ae"
 dependencies = [
  "either",
  "lazy_static",
@@ -2616,9 +2588,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df6e476185f92a12c072be4a189a0210dcdcf512a1891d6dff9edb874deadc6"
+checksum = "5acdd78cb4ba54c0045ac14f62d8f94a03d10047904ae2a40afa1e99d8f70825"
 dependencies = [
  "windows_aarch64_msvc",
  "windows_i686_gnu",
@@ -2629,45 +2601,46 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5"
+checksum = "17cffbe740121affb56fad0fc0e421804adf0ae00891205213b5cecd30db881d"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615"
+checksum = "2564fde759adb79129d9b4f54be42b32c89970c18ebf93124ca8870a498688ed"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172"
+checksum = "9cd9d32ba70453522332c14d38814bceeb747d80b3958676007acadd7e166956"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc"
+checksum = "cfce6deae227ee8d356d19effc141a509cc503dfd1f850622ec4b0f84428e1f4"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
+checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
 
 [[package]]
 name = "zip"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6fa4aa90e99fb8d701bda16fb040d8ed2f9c7176fb44de750e880a74b580315"
+checksum = "bf225bcf73bb52cbb496e70475c7bd7a3f769df699c0020f6c7bd9a96dcf0b8d"
 dependencies = [
  "aes",
  "byteorder",
  "bzip2",
  "constant_time_eq",
  "crc32fast",
+ "crossbeam-utils",
  "flate2",
  "hmac",
  "pbkdf2",

--- a/bazelfe-core/Cargo.toml
+++ b/bazelfe-core/Cargo.toml
@@ -56,51 +56,50 @@ async-stream = "0.3.3"
 async-trait = "0.1.53"
 byteorder = "1.4.3"
 bytes = "1.1.0"
-clap = {version = "3.1", features = ["derive", "env"]}
+clap = { version = "3.1.8", features = ["derive", "env"] }
 ctrlc = "3.2.1"
 exec = "0.3.1"
 lazy_static = "1.4.0"
-log = "0.4"
+log = "0.4.16"
 nom = "7.1.1"
-pretty_env_logger = "0.4"
-prost = "0.9"
-prost-types = "0.9"
+pretty_env_logger = "0.4.0"
+prost = "0.10.0"
+prost-types = "0.10.0"
 rand = "0.8.5"
 regex = "1.5.5"
-serde = { version = "1.0", features = ["derive"] }
-dynfmt = {version ="0.1.5", features = ["curly"]}
-serde_derive = "1.0.126"
+serde = { version = "1.0.136", features = ["derive"] }
+dynfmt = { version = "0.1.5", features = ["curly"] }
+serde_derive = "1.0.136"
 toml = "0.5.8"
 walkdir = "2.3.2"
 shellwords = "1.1.0"
-zip = "0.6.0"
+zip = "0.6.2"
 thiserror = "1.0.30"
-fork = {version = "0.1.19", optional=true}
+fork = { version = "0.1.19", optional = true }
 serde_json = "1.0.79"
-stdio-override = {version = "0.1.3", optional = true}
+stdio-override = { version = "0.1.3", optional = true }
 libc = "0.2.121"
-crossbeam-channel = {version = "0.5.4", optional = true}
-notify = {version = "5.0.0-pre.14", optional = true}
-tarpc = {version = "0.27.2", features = ["tokio1", "serde1", "serde-transport"], optional=true}
-tokio-serde = { version = "0.8", features = ["bincode"] , optional=true}
-tokio-util = { version = "0.6.9", features = ["compat"] }
+crossbeam-channel = { version = "0.5.4", optional = true }
+notify = { version = "5.0.0-pre.14", optional = true }
+tokio-serde = { version = "0.8.0", features = ["bincode"], optional = true }
+tokio-util = { version = "0.7.1", features = ["compat"] }
 sha2 = "0.10.2"
-nix = "0.23.0"
-flume = {version = "0.10.12", optional = true}
-trim-margin = {version = "0.1.0", optional = true}
-dashmap = {version = "5.2.0", optional = true}
-tui = {version = "0.17.0", default_features = false, features = ["crossterm"], optional = true}
-crossterm = {version = "0.23.1", optional = true}
-muncher = {version  = "0.7.0", optional = true}
+nix = "0.23.1"
+flume = { version = "0.10.12", optional = true }
+trim-margin = { version = "0.1.0", optional = true }
+dashmap = { version = "5.2.0", optional = true }
+tui = { version = "0.17.0", default_features = false, features = ["crossterm"], optional = true }
+crossterm = { version = "0.23.2", optional = true }
+muncher = { version = "0.7.0", optional = true }
 humantime = "2.1.0"
-tempfile = {version = "3.2.0", optional = true}
-anyhow = "1.0.54"
-ignore = "0.4"
+tempfile = { version = "3.3.0", optional = true }
+anyhow = "1.0.56"
+ignore = "0.4.18"
 
 
 [build-dependencies]
-vergen = "7.0"
-anyhow = "1.0.54"
+vergen = "7.0.0"
+anyhow = "1.0.56"
 
 [dependencies.bazelfe-protos]
 path = "../bazelfe-protos"
@@ -108,11 +107,11 @@ path = "../bazelfe-protos"
 [dependencies.futures]
 default-features = false
 features = ["alloc"]
-version = "0.3.18"
+version = "0.3.21"
 
 [dependencies.tokio]
 features = ["full"]
-version = "1"
+version = "1.17.0"
 
 [dependencies.tokio-stream]
 features = ["net"]
@@ -120,19 +119,19 @@ version = "0.1.8"
 
 [dependencies.tonic]
 features = ["tls"]
-version = "0.6.1"
+version = "0.7.1"
 
 [dev-dependencies]
 once_cell = "1.10.0"
 pinky-swear = "6.1.0"
-tower = "0.4"
-tempfile = {version = "3.2.0"}
+tower = "0.4.12"
+tempfile = "3.3.0"
 
 [features]
 default = []
 dev-binaries = []
 autotest-action = ["tui", "crossterm", "muncher", "tempfile", "bazelfe-daemon"]
-bazelfe-daemon = ["notify", "tarpc", "tokio-serde", "flume", "trim-margin", "dashmap", "fork", "stdio-override"]
+bazelfe-daemon = ["notify", "tokio-serde", "flume", "trim-margin", "dashmap", "fork", "stdio-override"]
 
 [lib]
 name = "bazelfe_core"

--- a/bazelfe-core/Cargo.toml
+++ b/bazelfe-core/Cargo.toml
@@ -95,6 +95,7 @@ humantime = "2.1.0"
 tempfile = { version = "3.3.0", optional = true }
 anyhow = "1.0.56"
 ignore = "0.4.18"
+tower = { version = "0.4" }
 
 
 [build-dependencies]

--- a/bazelfe-core/src/bazel_runner/auto_test_action/command_line_driver.rs
+++ b/bazelfe-core/src/bazel_runner/auto_test_action/command_line_driver.rs
@@ -1,6 +1,5 @@
-use crate::bazel_runner_daemon::daemon_service::FileStatus;
-
 use super::{app::App, ui};
+use bazelfe_protos::bazel_tools::daemon_service::FileStatus;
 use crossterm::{
     event::{self, DisableMouseCapture, EnableMouseCapture, Event as CEvent, KeyCode, KeyEvent},
     execute,

--- a/bazelfe-core/src/bazel_runner/auto_test_action/ui.rs
+++ b/bazelfe-core/src/bazel_runner/auto_test_action/ui.rs
@@ -202,7 +202,7 @@ where
                     format!("{:<14}", format!("{} ago", format_duration(elapsed))),
                     time_style,
                 ),
-                Span::raw(pb.to_string_lossy()),
+                Span::raw(pb.clone()),
             ])];
             ListItem::new(content)
         })

--- a/bazelfe-core/src/bazel_runner/command_line_rewriter_action.rs
+++ b/bazelfe-core/src/bazel_runner/command_line_rewriter_action.rs
@@ -136,7 +136,7 @@ mod tests {
             &mut passthrough_command_line,
             &CommandLineRewriter::default(),
             #[cfg(feature = "bazelfe-daemon")]
-            &None,
+            &mut None,
         )
         .await
         .unwrap();
@@ -169,7 +169,7 @@ mod tests {
             &mut passthrough_command_line,
             &rewrite_config,
             #[cfg(feature = "bazelfe-daemon")]
-            &None,
+            &mut None,
         )
         .await
         .unwrap();
@@ -203,7 +203,7 @@ mod tests {
             &mut passthrough_command_line,
             &rewrite_config,
             #[cfg(feature = "bazelfe-daemon")]
-            &None,
+            &mut None,
         )
         .await;
 

--- a/bazelfe-core/src/bazel_runner/configured_bazel_runner.rs
+++ b/bazelfe-core/src/bazel_runner/configured_bazel_runner.rs
@@ -191,9 +191,7 @@ impl<
     pub fn new(
         config: Arc<Config>,
         configured_bazel: ConfiguredBazel,
-        #[cfg(feature = "bazelfe-daemon")] runner_daemon: Option<
-            DaemonServiceClient<Channel>,
-        >,
+        #[cfg(feature = "bazelfe-daemon")] runner_daemon: Option<DaemonServiceClient<Channel>>,
         index_table: crate::index_table::IndexTable,
         bazel_command_line: ParsedCommandLine,
         process_build_failures: Arc<ProcessBazelFailures<T, U>>,

--- a/bazelfe-core/src/bazel_runner/configured_bazel_runner.rs
+++ b/bazelfe-core/src/bazel_runner/configured_bazel_runner.rs
@@ -15,10 +15,12 @@ use crate::{
     },
 };
 use crate::{build_events::build_event_server::bazel_event, config::Config};
+use bazelfe_protos::bazel_tools::daemon_service::daemon_service_client::DaemonServiceClient;
 use std::sync::Arc;
 use thiserror::Error;
 
 use tokio::sync::{Mutex, RwLock};
+use tonic::transport::Channel;
 
 use super::processor_activity::*;
 
@@ -145,7 +147,7 @@ pub struct ConfiguredBazelRunner<
     config: Arc<Config>,
     pub configured_bazel: ConfiguredBazel,
     #[cfg(feature = "bazelfe-daemon")]
-    pub runner_daemon: Option<crate::bazel_runner_daemon::daemon_service::RunnerDaemonClient>,
+    pub runner_daemon: Option<DaemonServiceClient<Channel>>,
     _index_table: crate::index_table::IndexTable,
     pub bazel_command_line: ParsedCommandLine,
     process_build_failures: Arc<ProcessBazelFailures<T, U>>,
@@ -190,7 +192,7 @@ impl<
         config: Arc<Config>,
         configured_bazel: ConfiguredBazel,
         #[cfg(feature = "bazelfe-daemon")] runner_daemon: Option<
-            crate::bazel_runner_daemon::daemon_service::RunnerDaemonClient,
+            DaemonServiceClient<Channel>,
         >,
         index_table: crate::index_table::IndexTable,
         bazel_command_line: ParsedCommandLine,
@@ -246,7 +248,7 @@ impl<
             &mut self.bazel_command_line,
             &self.config.command_line_rewriter,
             #[cfg(feature = "bazelfe-daemon")]
-            &self.runner_daemon,
+            &mut self.runner_daemon,
         )
         .await?;
 

--- a/bazelfe-core/src/bazel_runner_daemon/daemon_server.rs
+++ b/bazelfe-core/src/bazel_runner_daemon/daemon_server.rs
@@ -1,6 +1,11 @@
+use bazelfe_protos::bazel_tools::daemon_service::daemon_service_server::{
+    DaemonService, DaemonServiceServer,
+};
+use bazelfe_protos::bazel_tools::daemon_service::WaitForFilesRequest;
 use bazelfe_protos::*;
 use std::path::Path;
 use std::sync::atomic::Ordering;
+use std::sync::Arc;
 use std::{
     collections::{HashMap, HashSet},
     ops::{Add, Sub},
@@ -8,17 +13,17 @@ use std::{
     sync::atomic::{AtomicU32, AtomicUsize},
     time::Duration,
 };
+use tokio_stream::wrappers::UnixListenerStream;
+use tonic::transport::Channel;
+use tonic::{Request, Response};
 
+use bazel_tools::daemon_service;
 use dashmap::DashMap;
-use std::{error::Error, sync::Arc};
-use tarpc::serde_transport as transport;
-use tarpc::server::Channel;
+use std::error::Error;
 use tokio::{sync::Mutex, task::JoinHandle};
 
+use crate::config::daemon_config::NotifyRegexes;
 use crate::config::DaemonConfig;
-use crate::{
-    bazel_runner_daemon::daemon_service::RunnerDaemon, config::daemon_config::NotifyRegexes,
-};
 use std::time::Instant;
 use tokio::net::UnixListener;
 use tokio_serde::formats::Bincode;
@@ -74,13 +79,13 @@ impl Default for TargetState {
 }
 
 // If data arrives too quickly, we may start reporting times in the future!
-static mut CURRENT_TIME: u128 = 0;
-fn monotonic_current_time() -> u128 {
+static mut CURRENT_TIME: u64 = 0;
+fn monotonic_current_time() -> daemon_service::Instant {
     let ret = unsafe { CURRENT_TIME };
     unsafe {
         CURRENT_TIME += 1;
     }
-    ret
+    daemon_service::Instant { value: ret }
 }
 fn target_as_path(s: &String) -> Option<PathBuf> {
     let pb = PathBuf::from(s.replace(":", "/").replace("//", ""));
@@ -237,13 +242,14 @@ use crate::jvm_indexer::bazel_query::BazelQuery;
 #[derive(Debug)]
 struct TargetCache {
     target_state: Arc<TargetState>,
-    last_files_updated: Arc<Mutex<HashMap<PathBuf, (u128, Instant, Option<Vec<u8>>)>>>,
+    last_files_updated:
+        Arc<Mutex<HashMap<PathBuf, (daemon_service::Instant, Instant, Option<Vec<u8>>)>>>,
     inotify_ignore_regexes: NotifyRegexes,
     pending_hydrations: Arc<AtomicUsize>,
     bazel_query: Arc<Mutex<Box<dyn BazelQuery>>>,
-    inotify_receiver: Arc<flume::Receiver<u128>>,
-    inotify_sender: Arc<flume::Sender<u128>>,
-    last_update_ts: Arc<Mutex<u128>>,
+    inotify_receiver: Arc<flume::Receiver<daemon_service::Instant>>,
+    inotify_sender: Arc<flume::Sender<daemon_service::Instant>>,
+    last_update_ts: Arc<Mutex<daemon_service::Instant>>,
 }
 
 impl TargetCache {
@@ -251,7 +257,8 @@ impl TargetCache {
         daemon_config: &DaemonConfig,
         bazel_query: &Arc<Mutex<Box<dyn BazelQuery>>>,
     ) -> Self {
-        let (inotify_event_occured, inotify_receiver) = flume::unbounded::<u128>();
+        let (inotify_event_occured, inotify_receiver) =
+            flume::unbounded::<daemon_service::Instant>();
 
         Self {
             target_state: Default::default(),
@@ -383,14 +390,17 @@ impl TargetCache {
         }
     }
 
-    pub async fn wait_for_files(&self, instant: u128) -> Vec<super::daemon_service::FileStatus> {
+    pub async fn wait_for_files(
+        &self,
+        instant: daemon_service::Instant,
+    ) -> Vec<daemon_service::FileStatus> {
         let start_time = Instant::now();
         let max_wait = Duration::from_millis(20);
         let spin_wait = Duration::from_millis(3);
 
         loop {
             if *self.last_update_ts.lock().await > instant {
-                debug!("Last update timing indicates we should just try get recent files as of instant: {}", instant);
+                debug!("Last update timing indicates we should just try get recent files as of instant: {}", instant.value);
                 return self.get_recent_files(instant).await;
             }
 
@@ -410,13 +420,19 @@ impl TargetCache {
         }
     }
 
-    pub async fn get_recent_files(&self, instant: u128) -> Vec<super::daemon_service::FileStatus> {
+    pub async fn get_recent_files(
+        &self,
+        instant: daemon_service::Instant,
+    ) -> Vec<daemon_service::FileStatus> {
         let lock = self.last_files_updated.lock().await;
 
         lock.iter()
             .filter_map(|(k, (v, _, _))| {
                 if *v > instant {
-                    Some(super::daemon_service::FileStatus(k.clone(), *v))
+                    Some(daemon_service::FileStatus {
+                        path: k.to_string_lossy().to_string(),
+                        updated: Some(*v),
+                    })
                 } else {
                     None
                 }
@@ -434,61 +450,96 @@ struct DaemonServerInstance {
     pub bazel_binary_path: Arc<PathBuf>,
 }
 
-#[tarpc::server]
-impl super::daemon_service::RunnerDaemon for DaemonServerInstance {
+#[tonic::async_trait]
+impl DaemonService for DaemonServerInstance {
     async fn wait_for_files(
-        self,
-        _: tarpc::context::Context,
-        instant: u128,
-    ) -> Vec<super::daemon_service::FileStatus> {
+        &self,
+        request: Request<daemon_service::WaitForFilesRequest>,
+    ) -> Result<Response<daemon_service::WaitForFilesResponse>, tonic::Status> {
         self.most_recent_call
             .fetch_add(1, std::sync::atomic::Ordering::Release);
-        self.target_cache.wait_for_files(instant).await
+        let files = self
+            .target_cache
+            .wait_for_files(request.into_inner().value.unwrap())
+            .await;
+
+        Ok(Response::new(daemon_service::WaitForFilesResponse {
+            value: files,
+        }))
     }
 
     async fn recently_changed_files(
-        self,
-        _: tarpc::context::Context,
-        instant: u128,
-    ) -> Vec<super::daemon_service::FileStatus> {
+        &self,
+        request: Request<daemon_service::RecentlyChangedFilesRequest>,
+    ) -> Result<Response<daemon_service::RecentlyChangedFilesResponse>, tonic::Status> {
         self.most_recent_call
             .fetch_add(1, std::sync::atomic::Ordering::Release);
-        self.target_cache.get_recent_files(instant).await
+
+        let instant = request.into_inner().value.unwrap_or_default();
+        let files = self.target_cache.get_recent_files(instant).await;
+        Ok(Response::new(
+            daemon_service::RecentlyChangedFilesResponse { value: files },
+        ))
     }
 
-    async fn ping(self, _: tarpc::context::Context) -> super::ExecutableId {
+    async fn ping(
+        &self,
+        _: Request<daemon_service::PingRequest>,
+    ) -> Result<Response<daemon_service::PingResponse>, tonic::Status> {
         self.most_recent_call
             .fetch_add(1, std::sync::atomic::Ordering::Release);
-        self.executable_id.as_ref().clone()
+
+        Ok(Response::new(daemon_service::PingResponse {
+            executable_id: Some(self.executable_id.as_ref().clone()),
+        }))
     }
 
     async fn recently_invalidated_targets(
-        self,
-        ctx: tarpc::context::Context,
-        distance: u32,
-    ) -> Vec<super::daemon_service::Targets> {
+        &self,
+        request: Request<daemon_service::RecentlyInvalidatedTargetsRequest>,
+    ) -> Result<Response<daemon_service::RecentlyInvalidatedTargetsResponse>, tonic::Status> {
         self.most_recent_call
             .fetch_add(1, std::sync::atomic::Ordering::Release);
 
-        let recent_files = self.target_cache.get_recent_files(0).await;
-        match self
-            .targets_from_files(ctx, recent_files, distance, true)
-            .await
+        let request = request.into_inner();
+
+        let recent_files = self
+            .target_cache
+            .get_recent_files(daemon_service::Instant { value: 0 })
+            .await;
+        let targets = match self
+            .targets_from_files(Request::new(daemon_service::TargetsFromFilesRequest {
+                files: recent_files,
+                distance: request.distance,
+                was_in_query: true,
+            }))
+            .await?
+            .into_inner()
+            .response
+            .unwrap_or(daemon_service::targets_from_files_response::Response::InQuery(true))
         {
-            super::daemon_service::TargetsFromFilesResponse::Targets(t) => t,
-            super::daemon_service::TargetsFromFilesResponse::InQuery => Vec::default(),
-        }
+            daemon_service::targets_from_files_response::Response::InQuery(_) => Vec::default(),
+            daemon_service::targets_from_files_response::Response::Targets(t) => t.targets,
+        };
+
+        Ok(Response::new(
+            daemon_service::RecentlyInvalidatedTargetsResponse {
+                targets: Some(daemon_service::Targets { targets }),
+            },
+        ))
     }
 
     async fn targets_from_files(
-        self,
-        _: tarpc::context::Context,
-        files: Vec<super::daemon_service::FileStatus>,
-        distance: u32,
-        was_in_query: bool,
-    ) -> super::daemon_service::TargetsFromFilesResponse {
+        &self,
+        request: Request<daemon_service::TargetsFromFilesRequest>,
+    ) -> Result<Response<daemon_service::TargetsFromFilesResponse>, tonic::Status> {
         self.most_recent_call
             .fetch_add(1, std::sync::atomic::Ordering::Release);
+
+        let request = request.into_inner();
+        let was_in_query = request.was_in_query;
+        let distance = request.distance;
+        let files = request.files;
 
         let start_time = Instant::now();
         while self
@@ -498,16 +549,20 @@ impl super::daemon_service::RunnerDaemon for DaemonServerInstance {
             > 0
         {
             if start_time.elapsed() > Duration::from_millis(100) || !was_in_query {
-                return super::daemon_service::TargetsFromFilesResponse::InQuery;
+                return Ok(Response::new(daemon_service::TargetsFromFilesResponse {
+                    response: Some(
+                        daemon_service::targets_from_files_response::Response::InQuery(true),
+                    ),
+                }));
             }
             tokio::time::sleep(Duration::from_millis(5)).await;
         }
         let target_ids = files.iter().filter_map(|f| {
-            let path = &f.0;
+            let path = &f.path;
             self.target_cache
                 .target_state
                 .src_file_to_target
-                .get(path)
+                .get(&PathBuf::from(path))
                 .map(|e| *e.value())
         });
 
@@ -538,60 +593,65 @@ impl super::daemon_service::RunnerDaemon for DaemonServerInstance {
             match target_data.value() {
                 TargetType::Rule(r) => {
                     if r.is_test {
-                        result_targets.push(super::daemon_service::Targets::Test(
-                            super::daemon_service::TestTarget {
-                                target_label: r.target_label.clone(),
-                            },
-                        ));
+                        result_targets.push(daemon_service::Target {
+                            target_response: Some(
+                                daemon_service::target::TargetResponse::TestLabel(
+                                    r.target_label.clone(),
+                                ),
+                            ),
+                        });
                     } else {
-                        result_targets.push(super::daemon_service::Targets::Build(
-                            super::daemon_service::BuildTarget {
-                                target_label: r.target_label.clone(),
-                            },
-                        ));
+                        result_targets.push(daemon_service::Target {
+                            target_response: Some(
+                                daemon_service::target::TargetResponse::BuildLabel(
+                                    r.target_label.clone(),
+                                ),
+                            ),
+                        });
                     }
                 }
                 TargetType::Src(_) => {}
             }
         }
-        super::daemon_service::TargetsFromFilesResponse::Targets(result_targets)
+
+        return Ok(Response::new(daemon_service::TargetsFromFilesResponse {
+            response: Some(
+                daemon_service::targets_from_files_response::Response::Targets(
+                    daemon_service::Targets {
+                        targets: result_targets,
+                    },
+                ),
+            ),
+        }));
     }
 
-    async fn request_instant(self, _: tarpc::context::Context) -> u128 {
-        monotonic_current_time()
+    async fn request_instant(
+        &self,
+        _: Request<daemon_service::RequestInstantRequest>,
+    ) -> Result<Response<daemon_service::RequestInstantResponse>, tonic::Status> {
+        todo!()
+        // Ok(Response::new(daemon_service::RequestInstantResponse { value: monotonic_current_time() }))
     }
 }
 
-async fn start_tarpc_server<F>(
+async fn start_server(
     path: &PathBuf,
-    daemon_server_builder: F,
-) -> Result<JoinHandle<()>, Box<dyn Error>>
-where
-    F: Fn() -> DaemonServerInstance + Send + 'static,
-{
+    daemon_server_builder: DaemonServerInstance,
+) -> Result<JoinHandle<()>, Box<dyn Error>> {
     let bind_path = PathBuf::from(path);
-    let stream = UnixListener::bind(bind_path)?;
-    let codec_builder = LengthDelimitedCodec::builder();
+    let uds = UnixListener::bind(bind_path)?;
+    let uds_stream = UnixListenerStream::new(uds);
 
     Ok(tokio::spawn(async move {
-        loop {
-            if let Ok((conn, _)) = stream.accept().await {
-                let framed = codec_builder.new_framed(conn);
-                let transport = transport::new(framed, Bincode::default());
-
-                eprintln!("Client connected!");
-                let fut = tarpc::server::BaseChannel::with_defaults(transport)
-                    .execute(daemon_server_builder().serve());
-
-                tokio::spawn(async move {
-                    fut.await;
-                });
-            } else {
-                eprintln!("Socket dead, quitting.");
-
-                break;
-            }
-        }
+        tonic::transport::Server::builder()
+            .add_service(
+                daemon_service::daemon_service_server::DaemonServiceServer::new(
+                    daemon_server_builder,
+                ),
+            )
+            .serve_with_incoming(uds_stream)
+            .await
+            .unwrap()
     }))
 }
 
@@ -659,13 +719,17 @@ pub async fn main(
     let captured_daemon_config = Arc::new(daemon_config.clone());
     let captured_bazel_binary_path = Arc::new(bazel_binary_path.to_path_buf());
     println!("Starting tarpc");
-    start_tarpc_server(&paths.socket_path, move || DaemonServerInstance {
-        executable_id: executable_id.clone(),
-        most_recent_call: captured_most_recent_call.clone(),
-        target_cache: captured_target_cache.clone(),
-        daemon_config: captured_daemon_config.clone(),
-        bazel_binary_path: captured_bazel_binary_path.clone(),
-    })
+
+    start_server(
+        &paths.socket_path,
+        DaemonServerInstance {
+            executable_id: executable_id.clone(),
+            most_recent_call: captured_most_recent_call.clone(),
+            target_cache: captured_target_cache.clone(),
+            daemon_config: captured_daemon_config.clone(),
+            bazel_binary_path: captured_bazel_binary_path.clone(),
+        },
+    )
     .await?;
 
     let current_dir = current_dir;

--- a/bazelfe-core/src/bazel_runner_daemon/daemon_server.rs
+++ b/bazelfe-core/src/bazel_runner_daemon/daemon_server.rs
@@ -1,7 +1,4 @@
-use bazelfe_protos::bazel_tools::daemon_service::daemon_service_server::{
-    DaemonService, DaemonServiceServer,
-};
-use bazelfe_protos::bazel_tools::daemon_service::WaitForFilesRequest;
+use bazelfe_protos::bazel_tools::daemon_service::daemon_service_server::DaemonService;
 use bazelfe_protos::*;
 use std::path::Path;
 use std::sync::atomic::Ordering;
@@ -14,7 +11,6 @@ use std::{
     time::Duration,
 };
 use tokio_stream::wrappers::UnixListenerStream;
-use tonic::transport::Channel;
 use tonic::{Request, Response};
 
 use bazel_tools::daemon_service;
@@ -26,13 +22,11 @@ use crate::config::daemon_config::NotifyRegexes;
 use crate::config::DaemonConfig;
 use std::time::Instant;
 use tokio::net::UnixListener;
-use tokio_serde::formats::Bincode;
-use tokio_util::codec::LengthDelimitedCodec;
 
 #[derive(Debug, Clone)]
 struct Daemon {
-    config: Arc<DaemonConfig>,
-    bazel_binary_path: PathBuf,
+    _config: Arc<DaemonConfig>,
+    _bazel_binary_path: PathBuf,
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
@@ -168,12 +162,12 @@ impl TargetState {
     pub async fn hydrate_new_file_data(
         self: Arc<TargetState>,
         bazel_query: Arc<Mutex<Box<dyn BazelQuery>>>,
-        path: &PathBuf,
+        path: &Path,
     ) -> Result<(), Box<dyn Error>> {
         if self.src_file_to_target.contains_key(path) {
             return Ok(());
         }
-        let mut cur_path = Some(path.as_path());
+        let mut cur_path = Some(path);
         loop {
             if let Some(p) = cur_path {
                 if p.join("BUILD").exists() || p.join("WORKSPACE").exists() {
@@ -446,8 +440,8 @@ struct DaemonServerInstance {
     pub executable_id: Arc<super::ExecutableId>,
     pub most_recent_call: Arc<AtomicUsize>,
     pub target_cache: Arc<TargetCache>,
-    pub daemon_config: Arc<DaemonConfig>,
-    pub bazel_binary_path: Arc<PathBuf>,
+    pub _daemon_config: Arc<DaemonConfig>,
+    pub _bazel_binary_path: Arc<PathBuf>,
 }
 
 #[tonic::async_trait]
@@ -726,8 +720,8 @@ pub async fn main(
             executable_id: executable_id.clone(),
             most_recent_call: captured_most_recent_call.clone(),
             target_cache: captured_target_cache.clone(),
-            daemon_config: captured_daemon_config.clone(),
-            bazel_binary_path: captured_bazel_binary_path.clone(),
+            _daemon_config: captured_daemon_config.clone(),
+            _bazel_binary_path: captured_bazel_binary_path.clone(),
         },
     )
     .await?;

--- a/bazelfe-protos/Cargo.toml
+++ b/bazelfe-protos/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-tonic = { version = "0.6", features = ["tls"] }
-prost = "0.9"
+tonic = { version = "0.7.1", features = ["tls"] }
+prost = "0.10.0"
 # Required for wellknown types
-prost-types = "0.9"
+prost-types = "0.10.0"
  
 [build-dependencies]
-tonic-build = { version = "0.6", features = ["prost"] }
+tonic-build = { version = "0.7.0", features = ["prost"] }

--- a/bazelfe-protos/build.rs
+++ b/bazelfe-protos/build.rs
@@ -22,6 +22,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &[
             "proto/bazel_tools/request_files_service.proto",
             "proto/bazel_tools/upstream_service.proto",
+            "proto/bazel_tools/daemon_service.proto",
         ],
         &["proto/remote-apis", "proto/bazel_tools", "proto/googleapis"],
     )?;

--- a/bazelfe-protos/build.rs
+++ b/bazelfe-protos/build.rs
@@ -18,11 +18,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &["proto/remote-apis", "proto/googleapis"],
     )?;
 
+    tonic_build::configure()
+        .type_attribute("FileStatus", "#[derive(Hash, Eq, PartialOrd, Ord)]")
+        .type_attribute("Instant", "#[derive(Hash, Eq, PartialOrd, Ord)]")
+        .compile(
+            &["proto/bazel_tools/daemon_service/daemon_service.proto"],
+            &["proto/googleapis", "proto/bazel_tools/daemon_service"],
+        )?;
+
     tonic_build::configure().compile(
         &[
             "proto/bazel_tools/request_files_service.proto",
             "proto/bazel_tools/upstream_service.proto",
-            "proto/bazel_tools/daemon_service.proto",
         ],
         &["proto/remote-apis", "proto/bazel_tools", "proto/googleapis"],
     )?;

--- a/bazelfe-protos/proto/bazel_tools/daemon_service.proto
+++ b/bazelfe-protos/proto/bazel_tools/daemon_service.proto
@@ -1,0 +1,95 @@
+syntax = "proto3";
+
+package bazel_tools;
+
+option java_package = "io.bazeltools";
+option java_outer_classname = "DaemonServer";
+
+service DaemonService {
+    rpc RequestInstant(RequestInstanceRequest) returns (RequestInstanceResponse);
+    rpc RecentlyChangedFiles(RecentlyChangedFilesRequest) returns (RecentlyChangedFilesResponse);
+    rpc WaitForFiles(WaitForFilesFilesRequest) returns (WaitForFilesFilesResponse);
+    rpc TargetsFromFiles(TargetsFromFilesRequest) returns (TargetsFromFilesResponse);
+    rpc RecentlyInvalidatedTargets(RecentlyInvalidatedTargetsRequest) returns (RecentlyInvalidatedTargetsResponse);
+    rpc Ping(PingRequest) returns (PingResponse);
+}
+
+
+message RequestInstanceRequest {
+}
+message RequestInstanceResponse {
+  Instant value = 1;
+}
+
+
+message RecentlyChangedFilesRequest {
+  Instant value = 1;
+}
+message RecentlyChangedFilesResponse {
+  repeated FileStatus value = 1;
+}
+
+
+message WaitForFilesFilesRequest {
+  Instant value = 1;
+}
+message WaitForFilesFilesResponse {
+  repeated FileStatus value = 1;
+}
+
+message TargetsFromFilesRequest {
+  repeated FileStatus files = 1;
+  uint32 distance = 2;
+  bool was_in_query = 3;
+}
+
+message TargetsFromFilesResponse {
+  oneof response {
+    Targets targets = 1;
+    bool in_query = 2;
+  }
+}
+
+
+message RecentlyInvalidatedTargetsRequest {
+  uint32 distance = 2;
+}
+
+message RecentlyInvalidatedTargetsResponse {
+  Targets targets = 1;
+}
+
+message PingRequest {
+}
+
+message PingResponse {
+  ExecutableId executable_id = 1;
+}
+
+message Target {
+  oneof target_response {
+    string build_label = 1;
+    string test_label = 2;
+  }
+}
+
+message Targets {
+  repeated Target targets = 1;
+}
+
+
+message Instant {
+  uint64 value = 1;
+}
+
+message FileStatus {
+  string path = 1;
+  Instant updated = 2;
+}
+
+
+message ExecutableId {
+  string build_timestamp = 1;
+  string git_branch = 2;
+  string git_sha = 3;
+}

--- a/bazelfe-protos/proto/bazel_tools/daemon_service/daemon_service.proto
+++ b/bazelfe-protos/proto/bazel_tools/daemon_service/daemon_service.proto
@@ -1,23 +1,23 @@
 syntax = "proto3";
 
-package bazel_tools;
+package bazel_tools.daemon_service;
 
-option java_package = "io.bazeltools";
+option java_package = "io.bazeltools.daemon_service";
 option java_outer_classname = "DaemonServer";
 
 service DaemonService {
-    rpc RequestInstant(RequestInstanceRequest) returns (RequestInstanceResponse);
+    rpc RequestInstant(RequestInstantRequest) returns (RequestInstantResponse);
     rpc RecentlyChangedFiles(RecentlyChangedFilesRequest) returns (RecentlyChangedFilesResponse);
-    rpc WaitForFiles(WaitForFilesFilesRequest) returns (WaitForFilesFilesResponse);
+    rpc WaitForFiles(WaitForFilesRequest) returns (WaitForFilesResponse);
     rpc TargetsFromFiles(TargetsFromFilesRequest) returns (TargetsFromFilesResponse);
     rpc RecentlyInvalidatedTargets(RecentlyInvalidatedTargetsRequest) returns (RecentlyInvalidatedTargetsResponse);
     rpc Ping(PingRequest) returns (PingResponse);
 }
 
 
-message RequestInstanceRequest {
+message RequestInstantRequest {
 }
-message RequestInstanceResponse {
+message RequestInstantResponse {
   Instant value = 1;
 }
 
@@ -30,10 +30,10 @@ message RecentlyChangedFilesResponse {
 }
 
 
-message WaitForFilesFilesRequest {
+message WaitForFilesRequest {
   Instant value = 1;
 }
-message WaitForFilesFilesResponse {
+message WaitForFilesResponse {
   repeated FileStatus value = 1;
 }
 

--- a/bazelfe-protos/src/lib.rs
+++ b/bazelfe-protos/src/lib.rs
@@ -54,6 +54,38 @@ pub mod build {
 }
 
 pub mod bazel_tools {
+    pub mod daemon_service {
+        tonic::include_proto!("bazel_tools.daemon_service");
+        impl Copy for Instant {}
+
+        pub trait TargetUtils {
+            fn target_label(&self) -> &str;
+            fn is_test(&self) -> bool;
+        }
+        impl TargetUtils for Target {
+            fn is_test(&self) -> bool {
+                if let Some(res) = self.target_response.as_ref() {
+                    match res {
+                        target::TargetResponse::BuildLabel(_) => false,
+                        target::TargetResponse::TestLabel(_) => true,
+                    }
+                } else {
+                    false
+                }
+            }
+
+            fn target_label(&self) -> &str {
+                if let Some(res) = self.target_response.as_ref() {
+                    match res {
+                        target::TargetResponse::BuildLabel(label) => label.as_str(),
+                        target::TargetResponse::TestLabel(label) => label.as_str(),
+                    }
+                } else {
+                    ""
+                }
+            }
+        }
+    }
     tonic::include_proto!("bazel_tools");
 }
 


### PR DESCRIPTION
Tarpc seems to move slowly and depends on older versions of things in the tokio ecosystem. Causing a bit of a lag and missmatch. Its a bit more work, but just using protobuf over uds here