### PR TITLE
use the latest Vergen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -866,7 +866,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "sled",
- "sysinfo 0.29.0",
+ "sysinfo",
  "tempfile",
  "thiserror",
  "tokio",
@@ -1230,26 +1230,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
-name = "enum-iterator"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea166b3f7dc1032f7866d13f8d8e02c8d87507b61750176b86554964dc6a7bf"
-dependencies = [
- "enum-iterator-derive",
-]
-
-[[package]]
-name = "enum-iterator-derive"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "828de45d0ca18782232dfb8f3ea9cc428e8ced380eb26a520baaacfc70de39ce"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.107",
-]
-
-[[package]]
 name = "enum-ordinalize"
 version = "3.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1582,31 +1562,6 @@ dependencies = [
  "libc",
  "wasi",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "getset"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e45727250e75cc04ff2846a66397da8ef2b3db8e40e0cef4df67950a07621eb9"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.107",
-]
-
-[[package]]
-name = "git2"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf7f68c2995f392c49fffb4f95ae2c873297830eb25c6bc4c114ce8f4562acc"
-dependencies = [
- "bitflags",
- "libc",
- "libgit2-sys",
- "log",
- "url",
 ]
 
 [[package]]
@@ -1985,30 +1940,6 @@ name = "libc"
 version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
-
-[[package]]
-name = "libgit2-sys"
-version = "0.14.2+1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f3d95f6b51075fe9810a7ae22c7095f12b98005ab364d8544797a825ce946a4"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "pkg-config",
-]
-
-[[package]]
-name = "libz-sys"
-version = "1.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "linux-raw-sys"
@@ -2577,30 +2508,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.107",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2921,9 +2828,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
+checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
 
 [[package]]
 name = "ryu"
@@ -3245,20 +3152,6 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "sysinfo"
-version = "0.27.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a902e9050fca0a5d6877550b769abd2bd1ce8c04634b941dbe2809735e1a1e33"
-dependencies = [
- "cfg-if 1.0.0",
- "core-foundation-sys",
- "libc",
- "ntapi",
- "once_cell",
- "winapi 0.3.9",
-]
 
 [[package]]
 name = "sysinfo"
@@ -3848,20 +3741,12 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vergen"
-version = "7.5.1"
+version = "8.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f21b881cd6636ece9735721cf03c1fe1e774fe258683d084bb2812ab67435749"
+checksum = "6e03272e388fb78fc79481a493424f78d77be1d55f21bcd314b5a6716e195afe"
 dependencies = [
  "anyhow",
- "cfg-if 1.0.0",
- "enum-iterator",
- "getset",
- "git2",
- "rustc_version 0.4.0",
  "rustversion",
- "sysinfo 0.27.8",
- "thiserror",
- "time",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -695,6 +695,7 @@ dependencies = [
  "stdio-override",
  "tempfile",
  "thiserror",
+ "time",
  "tokio",
  "tokio-serde",
  "tokio-signal",
@@ -869,6 +870,7 @@ dependencies = [
  "sysinfo",
  "tempfile",
  "thiserror",
+ "time",
  "tokio",
  "tokio-serde",
  "tokio-stream",
@@ -3222,9 +3224,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.17"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
+checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
 dependencies = [
  "itoa",
  "serde",
@@ -3234,15 +3236,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.6"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
+checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
 dependencies = [
  "time-core",
 ]
@@ -3747,6 +3749,7 @@ checksum = "6e03272e388fb78fc79481a493424f78d77be1d55f21bcd314b5a6716e195afe"
 dependencies = [
  "anyhow",
  "rustversion",
+ "time",
 ]
 
 [[package]]

--- a/bazelfe-core/Cargo.toml
+++ b/bazelfe-core/Cargo.toml
@@ -63,6 +63,7 @@ regex = "1.8.1"
 serde = { version = "1.0.163", features = ["derive"] }
 dynfmt = { version = "0.1.5", features = ["curly"] }
 toml = "0.7.3"
+time = "0.3.21"
 walkdir = "2.3.3"
 shellwords = "1.1.0"
 zip = "0.6.6"
@@ -95,7 +96,7 @@ xml-rs = "0.8.11"
 
 
 [build-dependencies]
-vergen = "8.1.3"
+vergen = { version = "8.1.3", features = [ "build", "git", "gitcl" ]}
 anyhow = "1.0.71"
 
 [dependencies.bazelfe-protos]

--- a/bazelfe-core/Cargo.toml
+++ b/bazelfe-core/Cargo.toml
@@ -95,7 +95,7 @@ xml-rs = "0.8.11"
 
 
 [build-dependencies]
-vergen = "7.5.1"
+vergen = "8.1.3"
 anyhow = "1.0.71"
 
 [dependencies.bazelfe-protos]

--- a/bazelfe-core/build.rs
+++ b/bazelfe-core/build.rs
@@ -1,7 +1,9 @@
-use anyhow::Result;
-use vergen::{vergen, Config};
+use vergen::EmitBuilder;
+use std::error::Error;
 
-fn main() -> Result<()> {
+fn main() -> Result<(), Box<dyn Error>> {
     // Generate the default 'cargo:' instruction output
-    vergen(Config::default())
+    EmitBuilder::builder().emit()?;
+    Ok(())
 }
+

--- a/bazelfe-core/build.rs
+++ b/bazelfe-core/build.rs
@@ -1,9 +1,8 @@
-use vergen::EmitBuilder;
 use std::error::Error;
+use vergen::EmitBuilder;
 
 fn main() -> Result<(), Box<dyn Error>> {
     // Generate the default 'cargo:' instruction output
-    EmitBuilder::builder().emit()?;
+    EmitBuilder::builder().all_build().all_git().emit()?;
     Ok(())
 }
-

--- a/bzl-remote-core/Cargo.toml
+++ b/bzl-remote-core/Cargo.toml
@@ -53,6 +53,7 @@ flume = { version = "0.10.14" }
 trim-margin = { version = "0.1.0" }
 dashmap = { version = "5.4.0" }
 muncher = { version = "0.7.0" }
+time = "0.3.21"
 humantime = "2.1.0"
 tempfile = { version = "3.5.0" }
 anyhow = "1.0.71"
@@ -74,7 +75,7 @@ sysinfo = "0.29.0"
 
 
 [build-dependencies]
-vergen = "8.1.3"
+vergen = { version = "8.1.3", features = [ "build", "git", "gitcl" ]}
 anyhow = "1.0.71"
 
 [dependencies.bazelfe-protos]

--- a/bzl-remote-core/Cargo.toml
+++ b/bzl-remote-core/Cargo.toml
@@ -74,7 +74,7 @@ sysinfo = "0.29.0"
 
 
 [build-dependencies]
-vergen = "7.5.1"
+vergen = "8.1.3"
 anyhow = "1.0.71"
 
 [dependencies.bazelfe-protos]

--- a/bzl-remote-core/build.rs
+++ b/bzl-remote-core/build.rs
@@ -1,7 +1,8 @@
-use anyhow::Result;
-use vergen::{vergen, Config};
+use vergen::EmitBuilder;
+use std::error::Error;
 
-fn main() -> Result<()> {
+fn main() -> Result<(), Box<dyn Error>> {
     // Generate the default 'cargo:' instruction output
-    vergen(Config::default())
+    EmitBuilder::builder().emit()?;
+    Ok(())
 }

--- a/bzl-remote-core/build.rs
+++ b/bzl-remote-core/build.rs
@@ -1,8 +1,8 @@
-use vergen::EmitBuilder;
 use std::error::Error;
+use vergen::EmitBuilder;
 
 fn main() -> Result<(), Box<dyn Error>> {
     // Generate the default 'cargo:' instruction output
-    EmitBuilder::builder().emit()?;
+    EmitBuilder::builder().all_build().all_git().emit()?;
     Ok(())
 }


### PR DESCRIPTION
I'm not sure we are actually using anything here.

this tool is a tool to get build information (timestamps, git-shas, versions) into the build:

https://docs.rs/vergen/latest/vergen/

you can see an example from our code:
```
git_sha: String::from(env!("VERGEN_GIT_SHA")),
```
the env! macro runs at compile time to get the environmental variables set when cargo is running.