### PR TITLE
Improve label collection in junit conversion

### DIFF
--- a/bazelfe-bazel-wrapper/src/bep/build_events/build_event_server.rs
+++ b/bazelfe-bazel-wrapper/src/bep/build_events/build_event_server.rs
@@ -169,14 +169,14 @@ pub mod bazel_event {
 
             let target_complete: Option<Evt> = {
                 let target_label_opt = v.id.as_ref().and_then(|e| e.id.as_ref()).and_then(|e| {
-                    label_of(e).map(|label| {
-                        let opt_aspect = match e {
-                            build_event_stream::build_event_id::Id::TargetCompleted(
-                                target_completed_id,
-                            ) => Some(target_completed_id.aspect.clone()).filter(|e| !e.is_empty()),
-                            _ => None,
-                        };
-                        (label, opt_aspect)
+                    label_of(e).and_then(|label| match e {
+                        build_event_stream::build_event_id::Id::TargetCompleted(
+                            target_completed_id,
+                        ) => Some((
+                            label,
+                            Some(target_completed_id.aspect.clone()).filter(|e| !e.is_empty()),
+                        )),
+                        _ => None,
                     })
                 });
 


### PR DESCRIPTION
This adds a function to extract the label from all of the items that have them, and then uses that. This improves the collection of the failed labels:

original:
```
Have 12 aborted actions
  - //src/main/scala/com/netflix/rank/build_tools/apis/artifacts1:artifacts1
  - Unknown
  - Unknown
  - Unknown
  - Unknown
  - Unknown
  - Unknown
  - Unknown
  - Unknown
  - Unknown
  - Unknown
  - Unknown
```

after the change:
```
Have 12 aborted actions
  - //src/main/scala/com/netflix/rank/build_tools/apis/artifacts1:artifacts1
  - //src/main/scala/com/netflix/rank/build_tools/deployer/apps/invoker_app:invoker_app
  - //src/main/scala/com/netflix/rank/build_tools/mergebot/actions:actions
  - //src/main/scala/com/netflix/rank/build_tools/mergebot/apps/core:core
  - //src/main/scala/com/netflix/rank/build_tools/mergebot/worker_actions:worker_actions
  - //src/main/scala/com/netflix/rank/build_tools/deployer/apps/deployer_worker:deployer_worker
  - //src/main/scala/com/netflix/rank/build_tools/mergebot/apps/worker:app
  - //src/main/scala/com/netflix/rank/build_tools/mergebot/apps/worker:worker
  - //src/main/scala/com/netflix/rank/build_tools/mergebot/apps/bot_pr:bot_pr
  - //src/main/scala/com/netflix/rank/build_tools/mergebot/commands:commands
  - //src/main/scala/com/netflix/rank/build_tools/deployer/apps/invoker_app:invoker_bin
  - //src/main/scala/com/netflix/rank/build_tools/deployer/generic_deployments:generic_deployments
```