### PR TITLE
Report test timeouts into junit output

### DIFF
--- a/bazelfe-bazel-wrapper/src/bep/build_events/build_event_server.rs
+++ b/bazelfe-bazel-wrapper/src/bep/build_events/build_event_server.rs
@@ -321,14 +321,14 @@ pub mod bazel_event {
     }
     impl TestStatus {
         pub fn didnt_pass(&self) -> bool {
-            match self {
-                Self::Timeout => true,
-                Self::Failed => true,
-                Self::Incomplete => true,
-                Self::RemoteFailure => true,
-                Self::FailedToBuild => true,
-                _ => false,
-            }
+            matches!(
+                self,
+                Self::Timeout
+                    | Self::Failed
+                    | Self::Incomplete
+                    | Self::RemoteFailure
+                    | Self::FailedToBuild
+            )
         }
     }
     #[derive(Clone, PartialEq, Debug)]

--- a/bazelfe-bazel-wrapper/src/bep/build_events/build_event_server.rs
+++ b/bazelfe-bazel-wrapper/src/bep/build_events/build_event_server.rs
@@ -319,6 +319,18 @@ pub mod bazel_event {
         FailedToBuild,
         ToolHaltedBeforeTesting,
     }
+    impl TestStatus {
+        pub fn didnt_pass(&self) -> bool {
+            match self {
+                Self::Timeout => true,
+                Self::Failed => true,
+                Self::Incomplete => true,
+                Self::RemoteFailure => true,
+                Self::FailedToBuild => true,
+                _ => false,
+            }
+        }
+    }
     #[derive(Clone, PartialEq, Debug)]
     pub struct TestResultEvt {
         pub label: String,

--- a/bazelfe-core/src/bazel_runner/auto_test_action/progress_tab_updater.rs
+++ b/bazelfe-core/src/bazel_runner/auto_test_action/progress_tab_updater.rs
@@ -1,6 +1,7 @@
 use std::time::Instant;
 
 use bazelfe_bazel_wrapper::bep::{build_events, BazelEventHandler};
+use build_events::hydrated_stream::HasFiles;
 
 use crate::hydrated_stream_processors::BuildEventResponse;
 
@@ -48,7 +49,7 @@ impl BazelEventHandler<BuildEventResponse> for ProgressTabUpdater {
                         success: false,
                         label: af.label.clone(),
                         when: Instant::now(),
-                        files: af.files().clone(),
+                        files: af.files(),
                         target_kind: af.target_kind.clone(),
                         bazel_run_id,
                     })

--- a/bazelfe-core/src/hydrated_stream_processors/process_bazel_failures/shared_utils.rs
+++ b/bazelfe-core/src/hydrated_stream_processors/process_bazel_failures/shared_utils.rs
@@ -1,53 +1,15 @@
+use bazelfe_protos::build_event_stream;
 use std::path::PathBuf;
 
-use bazelfe_protos::build_event_stream;
-
 use bazelfe_bazel_wrapper::bep::build_events::hydrated_stream::{
-    ActionFailedErrorInfo, ActionSuccessInfo,
+    ActionFailedErrorInfo, ActionSuccessInfo, HasFiles,
 };
-
-pub(in crate::hydrated_stream_processors::process_bazel_failures) fn output_from_paths<'a>(
-    files: impl Iterator<Item = &'a build_event_stream::file::File>,
-) -> Vec<std::path::PathBuf> {
-    files
-        .flat_map(|e| match e {
-            build_event_stream::file::File::Uri(e) => {
-                if e.starts_with("file://") {
-                    let u: PathBuf = e.strip_prefix("file://").unwrap().into();
-                    Some(u)
-                } else {
-                    warn!("Path isn't a file, so skipping...{:?}", e);
-
-                    None
-                }
-            }
-            build_event_stream::file::File::Contents(_) => None,
-        })
-        .collect()
-}
-
-pub(in crate::hydrated_stream_processors::process_bazel_failures) fn output_success_paths(
-    data: &ActionSuccessInfo,
-) -> Vec<std::path::PathBuf> {
-    output_from_paths(
-        vec![&data.stdout, &data.stderr]
-            .iter()
-            .filter_map(|&e| e.as_ref())
-            .filter_map(|e| e.file.as_ref()),
-    )
-}
-
-pub(in crate::hydrated_stream_processors::process_bazel_failures) fn output_error_paths(
-    err_data: &ActionFailedErrorInfo,
-) -> Vec<std::path::PathBuf> {
-    output_from_paths(err_data.files().iter().filter_map(|e| e.file.as_ref()))
-}
 
 pub(in crate::hydrated_stream_processors::process_bazel_failures) async fn text_logs_from_success(
     action_success_info: &ActionSuccessInfo,
 ) -> Vec<String> {
     let mut error_data = Vec::default();
-    for path_str in output_success_paths(action_success_info).into_iter() {
+    for path_str in action_success_info.path_bufs().into_iter() {
         let path: PathBuf = path_str;
         if path.exists() {
             let file_len = std::fs::metadata(&path).unwrap().len();
@@ -64,7 +26,7 @@ pub(in crate::hydrated_stream_processors::process_bazel_failures) async fn text_
     action_failed_error_info: &ActionFailedErrorInfo,
 ) -> Vec<String> {
     let mut error_data = Vec::default();
-    for path_str in output_error_paths(action_failed_error_info).into_iter() {
+    for path_str in action_failed_error_info.path_bufs().into_iter() {
         let path: PathBuf = path_str;
         if path.exists() {
             let file_len = std::fs::metadata(&path).unwrap().len();

--- a/bazelfe-core/src/hydrated_stream_processors/process_bazel_failures/shared_utils.rs
+++ b/bazelfe-core/src/hydrated_stream_processors/process_bazel_failures/shared_utils.rs
@@ -1,4 +1,3 @@
-use bazelfe_protos::build_event_stream;
 use std::path::PathBuf;
 
 use bazelfe_bazel_wrapper::bep::build_events::hydrated_stream::{


### PR DESCRIPTION
an annoying issue for me is that timeouts, which are not uncommon in our builds, are not reported in the XML output, so we have to go fishing through all the stdout to see them.

This changes that by considering any non-success as a failure case. In my local tests that solved the issue of timeouts being ignored.