### PR TITLE
Bump to async-channel 2.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,13 +99,15 @@ checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
 
 [[package]]
 name = "async-channel"
-version = "1.9.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+checksum = "1ca33f4bc4ed1babef42cad36cc1f51fa88be00420404e5b1e80ab1b18f7678c"
 dependencies = [
  "concurrent-queue",
  "event-listener",
+ "event-listener-strategy",
  "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -981,9 +983,9 @@ dependencies = [
 
 [[package]]
 name = "concurrent-queue"
-version = "2.1.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c278839b831783b70278b14df4d45e1beb1aad306c07bb796637de9a0e323e8e"
+checksum = "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1292,9 +1294,24 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.5.3"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "exec"
@@ -2239,6 +2256,12 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "parking"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "parking_lot"

--- a/bazelfe-bazel-wrapper/Cargo.toml
+++ b/bazelfe-bazel-wrapper/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/bazel_command_line_parser/generate_bazel_command_line_app.rs"
 required-features = ["dev-binaries"]
 
 [dependencies]
-async-channel = "1.9.0"
+async-channel = "2.1.1"
 async-stream = "0.3.5"
 async-trait = "0.1.77"
 bytes = "1.5.0"

--- a/bazelfe-bazel-wrapper/src/bep/build_events/hydrated_stream.rs
+++ b/bazelfe-bazel-wrapper/src/bep/build_events/hydrated_stream.rs
@@ -13,6 +13,7 @@ use super::build_event_server::BuildEventAction;
 use bazelfe_protos::build_event_stream::NamedSetOfFiles;
 use bazelfe_protos::*;
 use std::path::PathBuf;
+use std::pin::pin;
 
 pub trait HasFiles {
     fn files(&self) -> Vec<build_event_stream::File>;
@@ -333,7 +334,7 @@ mod tests {
     #[tokio::test]
     async fn test_no_history() {
         let (tx, rx) = async_channel::unbounded();
-        let mut child_rx = HydratedInfo::build_transformer(rx);
+        let mut child_rx = pin!(HydratedInfo::build_transformer(rx));
 
         tx.send(BuildEventAction::BuildEvent(bazel_event::BazelBuildEvent {
             event: bazel_event::Evt::ActionCompleted(bazel_event::ActionCompletedEvt {
@@ -362,7 +363,7 @@ mod tests {
     #[tokio::test]
     async fn test_with_files() {
         let (tx, rx) = async_channel::unbounded();
-        let mut child_rx = HydratedInfo::build_transformer(rx);
+        let mut child_rx = pin!(HydratedInfo::build_transformer(rx));
 
         tx.send(BuildEventAction::BuildEvent(bazel_event::BazelBuildEvent {
             event: bazel_event::Evt::ActionCompleted(bazel_event::ActionCompletedEvt {
@@ -412,7 +413,7 @@ mod tests {
     #[tokio::test]
     async fn test_with_history() {
         let (tx, rx) = async_channel::unbounded();
-        let mut child_rx = HydratedInfo::build_transformer(rx);
+        let mut child_rx = pin!(HydratedInfo::build_transformer(rx));
 
         tx.send(BuildEventAction::BuildEvent(bazel_event::BazelBuildEvent {
             event: bazel_event::Evt::TargetConfigured(bazel_event::TargetConfiguredEvt {
@@ -471,7 +472,7 @@ mod tests {
     #[tokio::test]
     async fn state_resets_on_new_build() {
         let (tx, rx) = async_channel::unbounded();
-        let mut child_rx = HydratedInfo::build_transformer(rx);
+        let mut child_rx = pin!(HydratedInfo::build_transformer(rx));
 
         tx.send(BuildEventAction::BuildEvent(bazel_event::BazelBuildEvent {
             event: bazel_event::Evt::TargetConfigured(bazel_event::TargetConfiguredEvt {

--- a/bazelfe-core/Cargo.toml
+++ b/bazelfe-core/Cargo.toml
@@ -44,7 +44,7 @@ name = "bazel-runner"
 path = "src/bazel_runner/bazel_runner_app.rs"
 
 [dependencies]
-async-channel = "1.9.0"
+async-channel = "2.1.1"
 async-stream = "0.3.5"
 async-trait = "0.1.77"
 byteorder = "1.5.0"


### PR DESCRIPTION
replaces https://github.com/bazeltools/bazelfe/pull/998