### PR TITLE
Remove panics from xml writing

### DIFF
--- a/bazelfe-bazel-wrapper/src/bazel_command_line_parser/mod.rs
+++ b/bazelfe-bazel-wrapper/src/bazel_command_line_parser/mod.rs
@@ -329,7 +329,7 @@ pub fn parse_bazel_command_line(
             if cur_options.is_empty() {
                 break 'outer;
             } else {
-                action_options.extend(cur_options.into_iter());
+                action_options.extend(cur_options);
             }
         }
         action_args.extend(command_line_iter.cloned());

--- a/bazelfe-bazel-wrapper/src/bazel_subprocess_wrapper/mod.rs
+++ b/bazelfe-bazel-wrapper/src/bazel_subprocess_wrapper/mod.rs
@@ -148,7 +148,7 @@ async fn execute_tokio_subprocess(
                 break;
             }
             if show_output {
-                if let Err(_) = stdout.write_all(&buffer[0..bytes_read]).await {
+                if stdout.write_all(&buffer[0..bytes_read]).await.is_err() {
                     break;
                 }
             }
@@ -165,7 +165,7 @@ async fn execute_tokio_subprocess(
                 break;
             }
             if show_output {
-                if let Err(_) = stderr.write_all(&buffer[0..bytes_read]).await {
+                if stderr.write_all(&buffer[0..bytes_read]).await.is_err() {
                     break;
                 }
             }

--- a/bazelfe-bazel-wrapper/src/bep/build_events/build_event_server.rs
+++ b/bazelfe-bazel-wrapper/src/bep/build_events/build_event_server.rs
@@ -451,7 +451,7 @@ where
                         let sequence_number = build_event.sequence_number;
                     yield PublishBuildToolEventStreamResponse {
                         stream_id: build_event.stream_id.clone(),
-                        sequence_number: sequence_number
+                        sequence_number
                     };
 
             }

--- a/bazelfe-bazel-wrapper/src/bep/build_events/build_event_server.rs
+++ b/bazelfe-bazel-wrapper/src/bep/build_events/build_event_server.rs
@@ -91,10 +91,12 @@ pub mod bazel_event {
 
             let aborted: Option<Evt> = {
                 let abort_info = v.payload.as_ref().and_then(|e| match e {
-                    build_event_stream::build_event::Payload::Aborted(cfg) => Some((
-                        build_event_stream::aborted::AbortReason::from_i32(cfg.reason),
-                        cfg.description.clone(),
-                    )),
+                    build_event_stream::build_event::Payload::Aborted(cfg) => Some(
+                        match build_event_stream::aborted::AbortReason::try_from(cfg.reason) {
+                            Ok(ar) => (Some(ar), cfg.description.clone()),
+                            Err(_) => (None, cfg.description.clone()),
+                        },
+                    ),
                     _ => None,
                 });
                 let target_label_opt = v.id.as_ref().and_then(|e| e.id.as_ref()).and_then(label_of);

--- a/bazelfe-bazel-wrapper/src/bep/build_events/hydrated_stream.rs
+++ b/bazelfe-bazel-wrapper/src/bep/build_events/hydrated_stream.rs
@@ -13,7 +13,6 @@ use super::build_event_server::BuildEventAction;
 use bazelfe_protos::build_event_stream::NamedSetOfFiles;
 use bazelfe_protos::*;
 use std::path::PathBuf;
-use std::pin::pin;
 
 pub trait HasFiles {
     fn files(&self) -> Vec<build_event_stream::File>;
@@ -336,7 +335,7 @@ impl HydratedInfo {
                 }
             }
             HydratedInfo::ActionFailed(af) => Some(af.label.as_str()),
-            HydratedInfo::Progress(pe) => None,
+            HydratedInfo::Progress(_) => None,
             HydratedInfo::TestResult(tri) => Some(tri.test_summary_event.label.as_str()),
             HydratedInfo::ActionSuccess(asucc) => Some(asucc.label.as_str()),
             HydratedInfo::TargetComplete(tc) => Some(tc.label.as_str()),
@@ -352,7 +351,7 @@ mod tests {
     #[tokio::test]
     async fn test_no_history() {
         let (tx, rx) = async_channel::unbounded();
-        let mut child_rx = pin!(HydratedInfo::build_transformer(rx));
+        let mut child_rx = std::pin::pin!(HydratedInfo::build_transformer(rx));
 
         tx.send(BuildEventAction::BuildEvent(bazel_event::BazelBuildEvent {
             event: bazel_event::Evt::ActionCompleted(bazel_event::ActionCompletedEvt {
@@ -381,7 +380,7 @@ mod tests {
     #[tokio::test]
     async fn test_with_files() {
         let (tx, rx) = async_channel::unbounded();
-        let mut child_rx = pin!(HydratedInfo::build_transformer(rx));
+        let mut child_rx = std::pin::pin!(HydratedInfo::build_transformer(rx));
 
         tx.send(BuildEventAction::BuildEvent(bazel_event::BazelBuildEvent {
             event: bazel_event::Evt::ActionCompleted(bazel_event::ActionCompletedEvt {
@@ -431,7 +430,7 @@ mod tests {
     #[tokio::test]
     async fn test_with_history() {
         let (tx, rx) = async_channel::unbounded();
-        let mut child_rx = pin!(HydratedInfo::build_transformer(rx));
+        let mut child_rx = std::pin::pin!(HydratedInfo::build_transformer(rx));
 
         tx.send(BuildEventAction::BuildEvent(bazel_event::BazelBuildEvent {
             event: bazel_event::Evt::TargetConfigured(bazel_event::TargetConfiguredEvt {
@@ -490,7 +489,7 @@ mod tests {
     #[tokio::test]
     async fn state_resets_on_new_build() {
         let (tx, rx) = async_channel::unbounded();
-        let mut child_rx = pin!(HydratedInfo::build_transformer(rx));
+        let mut child_rx = std::pin::pin!(HydratedInfo::build_transformer(rx));
 
         tx.send(BuildEventAction::BuildEvent(bazel_event::BazelBuildEvent {
             event: bazel_event::Evt::TargetConfigured(bazel_event::TargetConfiguredEvt {

--- a/bazelfe-bazel-wrapper/src/bep/build_events/hydrated_stream.rs
+++ b/bazelfe-bazel-wrapper/src/bep/build_events/hydrated_stream.rs
@@ -323,6 +323,24 @@ impl HydratedInfo {
         });
         next_rx
     }
+
+    pub fn label(&self) -> Option<&str> {
+        match self {
+            HydratedInfo::BazelAbort(ba) =>
+            // this is a dance to return the ref
+            {
+                match &ba.label {
+                    Some(s) => Some(s.as_str()),
+                    None => None,
+                }
+            }
+            HydratedInfo::ActionFailed(af) => Some(af.label.as_str()),
+            HydratedInfo::Progress(pe) => None,
+            HydratedInfo::TestResult(tri) => Some(tri.test_summary_event.label.as_str()),
+            HydratedInfo::ActionSuccess(asucc) => Some(asucc.label.as_str()),
+            HydratedInfo::TargetComplete(tc) => Some(tc.label.as_str()),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/bazelfe-bazel-wrapper/src/bep/target_completed_tracker/mod.rs
+++ b/bazelfe-bazel-wrapper/src/bep/target_completed_tracker/mod.rs
@@ -16,13 +16,10 @@ impl<T> super::BazelEventHandler<T> for TargetCompletedTracker {
         _bazel_run_id: usize,
         event: &hydrated_stream::HydratedInfo,
     ) -> Vec<T> {
-        match event {
-            hydrated_stream::HydratedInfo::TargetComplete(tce) => {
-                let mut guard = self.expected_targets.lock().await;
-                guard.remove(&tce.label);
-            }
-            _ => (),
-        };
+        if let hydrated_stream::HydratedInfo::TargetComplete(tce) = event {
+            let mut guard = self.expected_targets.lock().await;
+            guard.remove(&tce.label);
+        }
         Vec::default()
     }
 }

--- a/bazelfe-core/src/bazel_runner/bazel_runner_inst.rs
+++ b/bazelfe-core/src/bazel_runner/bazel_runner_inst.rs
@@ -70,7 +70,7 @@ impl BazelRunner {
         if let Some(bazel_command_line_parser::Action::Custom(cust_str)) =
             self.bazel_command_line.action.as_ref()
         {
-            if CustomAction::AutoTest == parse_custom_action(&cust_str)? {
+            if CustomAction::AutoTest == parse_custom_action(cust_str)? {
                 self.config.daemon_config.enabled = true;
             }
         }

--- a/bazelfe-core/src/bazel_runner/processor_activity.rs
+++ b/bazelfe-core/src/bazel_runner/processor_activity.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use crate::hydrated_stream_processors::process_bazel_failures::{TargetStory, TargetStoryAction};
 
+#[derive(Default)]
 pub struct ProcessorActivity {
     pub jvm_segments_indexed: u32,
     pub actions_taken: u32,
@@ -61,14 +62,5 @@ impl ProcessorActivity {
 
         self.jvm_segments_indexed += o.jvm_segments_indexed;
         self.actions_taken += o.actions_taken;
-    }
-}
-impl Default for ProcessorActivity {
-    fn default() -> Self {
-        ProcessorActivity {
-            jvm_segments_indexed: 0,
-            actions_taken: 0,
-            target_story_actions: HashMap::new(),
-        }
     }
 }

--- a/bazelfe-core/src/bazel_runner/test_file_to_target/mod.rs
+++ b/bazelfe-core/src/bazel_runner/test_file_to_target/mod.rs
@@ -58,7 +58,7 @@ pub async fn run<B: BazelQuery>(
         };
 
         let query_for_target = bazel_query
-            .execute(&vec![
+            .execute(&[
                 String::from("query"),
                 format!(
                     "rdeps(//{}/..., {},1)",

--- a/bazelfe-core/src/bep_junit/bep_junit_app.rs
+++ b/bazelfe-core/src/bep_junit/bep_junit_app.rs
@@ -94,7 +94,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             }
             HydratedInfo::ActionFailed(action_failed) => {
                 failed_actions.push(action_failed.label.clone());
-                match emit_junit_xml_from_failed_action(&action_failed, &opt.junit_output_path) {
+                match emit_junit_xml_from_failed_action(action_failed, &opt.junit_output_path) {
                     Ok(_) => (),
                     Err(e) => failed_xml_writes.push((build_event, e)),
                 }

--- a/bazelfe-core/src/bep_junit/bep_junit_app.rs
+++ b/bazelfe-core/src/bep_junit/bep_junit_app.rs
@@ -1,14 +1,13 @@
 use bazelfe_bazel_wrapper::bep::build_events::build_event_server::BuildEventAction;
 use bazelfe_core::bep_junit::{
     emit_backup_error_data, emit_junit_xml_from_aborted_action, emit_junit_xml_from_failed_action,
-    label_to_junit_relative_path, suites_with_error_from_xml,
+    label_to_junit_relative_path,
 };
 
 use bazelfe_bazel_wrapper::bep::build_events::hydrated_stream::{HydratedInfo, HydratorState};
 use bazelfe_protos::build_event_stream::BuildEvent;
 use clap::Parser;
 use prost::Message;
-use std::cmp::Ordering;
 use std::collections::VecDeque;
 use std::error::Error;
 use std::os::unix::fs::MetadataExt;

--- a/bazelfe-core/src/bep_junit/failed_action.rs
+++ b/bazelfe-core/src/bep_junit/failed_action.rs
@@ -1,6 +1,7 @@
 use super::junit_xml_error_writer;
 
 use super::xml_utils::emit_junit_xml_from_failed_operation;
+use xml::writer::Error as XmlError;
 
 use bazelfe_bazel_wrapper::bep::build_events::hydrated_stream::{
     ActionFailedErrorInfo, BazelAbortErrorInfo,
@@ -11,7 +12,7 @@ pub fn emit_junit_xml_from_aborted_action(
     aborted_evt: &BazelAbortErrorInfo,
     abort_idx: usize,
     output_root: &Path,
-) {
+) -> Result<(), XmlError> {
     let label_name = aborted_evt
         .label
         .to_owned()
@@ -32,7 +33,10 @@ pub fn emit_junit_xml_from_aborted_action(
     emit_junit_xml_from_failed_operation(test_cases, label_name, output_root)
 }
 
-pub fn emit_junit_xml_from_failed_action(action: &ActionFailedErrorInfo, output_root: &Path) {
+pub fn emit_junit_xml_from_failed_action(
+    action: &ActionFailedErrorInfo,
+    output_root: &Path,
+) -> Result<(), XmlError> {
     emit_junit_xml_from_failed_operation(
         vec![generate_struct_from_failed_action(action)],
         action.label.clone(),

--- a/bazelfe-core/src/bep_junit/junit_xml_error_writer.rs
+++ b/bazelfe-core/src/bep_junit/junit_xml_error_writer.rs
@@ -1,4 +1,4 @@
-use xml::writer::XmlEvent;
+use xml::writer::{Error as XmlError, XmlEvent};
 
 use super::xml_utils::XmlWritable;
 
@@ -7,14 +7,17 @@ pub struct TestSuites {
     pub testsuites: Vec<TestSuite>,
 }
 impl XmlWritable for TestSuites {
-    fn write_xml<W: std::io::Write>(&self, writer: &mut xml::writer::EventWriter<W>) {
+    fn write_xml<W: std::io::Write>(
+        &self,
+        writer: &mut xml::writer::EventWriter<W>,
+    ) -> Result<(), XmlError> {
         let e = XmlEvent::start_element("testsuites");
-        writer.write(e).unwrap();
+        writer.write(e)?;
 
         for s in self.testsuites.iter() {
-            s.write_xml(writer);
+            s.write_xml(writer)?;
         }
-        writer.write(XmlEvent::end_element()).unwrap();
+        writer.write(XmlEvent::end_element())
     }
 }
 
@@ -26,7 +29,10 @@ pub struct TestSuite {
     pub testcases: Vec<TestCase>,
 }
 impl XmlWritable for TestSuite {
-    fn write_xml<W: std::io::Write>(&self, writer: &mut xml::writer::EventWriter<W>) {
+    fn write_xml<W: std::io::Write>(
+        &self,
+        writer: &mut xml::writer::EventWriter<W>,
+    ) -> Result<(), XmlError> {
         let tests = self.tests.to_string();
         let failures = self.failures.to_string();
         let e = XmlEvent::start_element("testsuite")
@@ -37,9 +43,9 @@ impl XmlWritable for TestSuite {
         writer.write(e).unwrap();
 
         for s in self.testcases.iter() {
-            s.write_xml(writer);
+            s.write_xml(writer)?;
         }
-        writer.write(XmlEvent::end_element()).unwrap();
+        writer.write(XmlEvent::end_element())
     }
 }
 
@@ -51,18 +57,21 @@ pub struct TestCase {
 }
 
 impl XmlWritable for TestCase {
-    fn write_xml<W: std::io::Write>(&self, writer: &mut xml::writer::EventWriter<W>) {
+    fn write_xml<W: std::io::Write>(
+        &self,
+        writer: &mut xml::writer::EventWriter<W>,
+    ) -> Result<(), XmlError> {
         let time = self.time.to_string();
         let e = XmlEvent::start_element("testcase")
             .attr("name", self.name.as_str())
             .attr("time", time.as_str());
 
-        writer.write(e).unwrap();
+        writer.write(e)?;
 
         for s in self.failures.iter() {
-            s.write_xml(writer);
+            s.write_xml(writer)?;
         }
-        writer.write(XmlEvent::end_element()).unwrap();
+        writer.write(XmlEvent::end_element())
     }
 }
 
@@ -74,15 +83,18 @@ pub struct Failure {
 }
 
 impl XmlWritable for Failure {
-    fn write_xml<W: std::io::Write>(&self, writer: &mut xml::writer::EventWriter<W>) {
+    fn write_xml<W: std::io::Write>(
+        &self,
+        writer: &mut xml::writer::EventWriter<W>,
+    ) -> Result<(), XmlError> {
         let e = XmlEvent::start_element("failure")
             .attr("message", self.message.as_str())
             .attr("type", self.tpe_name.as_str());
 
-        writer.write(e).unwrap();
+        writer.write(e)?;
 
-        writer.write(XmlEvent::CData(self.value.as_str())).unwrap();
-        writer.write(XmlEvent::end_element()).unwrap();
+        writer.write(XmlEvent::CData(self.value.as_str()))?;
+        writer.write(XmlEvent::end_element())
     }
 }
 

--- a/bazelfe-core/src/bep_junit/mod.rs
+++ b/bazelfe-core/src/bep_junit/mod.rs
@@ -1,7 +1,7 @@
 mod failed_action;
 pub mod junit_xml_error_writer;
 mod test_results_ops;
-mod xml_utils;
+pub mod xml_utils;
 
 pub use failed_action::emit_junit_xml_from_aborted_action;
 pub use failed_action::emit_junit_xml_from_failed_action;

--- a/bazelfe-core/src/bep_junit/test_results_ops.rs
+++ b/bazelfe-core/src/bep_junit/test_results_ops.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 use xml::reader::EventReader;
 use xml::reader::XmlEvent;
+use xml::writer::Error as XmlError;
 
 use bazelfe_bazel_wrapper::bep::build_events::hydrated_stream::TestResultInfo;
 
@@ -30,7 +31,10 @@ fn extract_file_content(test_result: &TestResultInfo) -> Vec<String> {
     r
 }
 
-pub fn emit_backup_error_data(test_result: &TestResultInfo, output_root: &Path) {
+pub fn emit_backup_error_data(
+    test_result: &TestResultInfo,
+    output_root: &Path,
+) -> Result<(), XmlError> {
     if test_result.test_summary_event.test_status.didnt_pass() {
         let label_name = test_result.test_summary_event.label.clone();
 
@@ -55,6 +59,8 @@ pub fn emit_backup_error_data(test_result: &TestResultInfo, output_root: &Path) 
         }];
 
         emit_junit_xml_from_failed_operation(test_cases, label_name, output_root)
+    } else {
+        Ok(())
     }
 }
 

--- a/bazelfe-core/src/bep_junit/xml_utils.rs
+++ b/bazelfe-core/src/bep_junit/xml_utils.rs
@@ -44,7 +44,7 @@ pub fn emit_junit_xml_from_failed_operation(
         Err(e) => {
             // we should remove the file when we fail
             std::fs::remove_file(output_file)?;
-            return Err(e);
+            Err(e)
         }
     }
 }

--- a/bazelfe-core/src/bep_junit/xml_utils.rs
+++ b/bazelfe-core/src/bep_junit/xml_utils.rs
@@ -1,17 +1,18 @@
-use std::path::Path;
-
-use crate::bep_junit::label_to_junit_relative_path;
+use std::{io::Write, path::Path};
 
 use super::junit_xml_error_writer;
+use crate::bep_junit::label_to_junit_relative_path;
+use xml::writer::{Error as XmlError, EventWriter};
 
 pub trait XmlWritable {
-    fn write_xml<W: std::io::Write>(&self, writer: &mut xml::writer::EventWriter<W>);
+    fn write_xml<W: std::io::Write>(&self, writer: &mut EventWriter<W>) -> Result<(), XmlError>;
 }
 
 pub fn xml_writable_to_string<T: XmlWritable>(t: &T) -> String {
     let mut v = Vec::default();
-    let mut xml_writer = xml::writer::EventWriter::new(&mut v);
-    t.write_xml(&mut xml_writer);
+    let mut xml_writer = EventWriter::new(&mut v);
+    t.write_xml(&mut xml_writer)
+        .expect("we don't expect writing to Vec<u8> to fail");
     drop(xml_writer);
     String::from_utf8(v).expect("Should emit sane UTF-8")
 }
@@ -20,12 +21,11 @@ pub fn emit_junit_xml_from_failed_operation(
     test_cases: Vec<junit_xml_error_writer::TestCase>,
     label_name: String,
     output_root: &Path,
-) {
+) -> Result<(), XmlError> {
     let output_folder = output_root.join(label_to_junit_relative_path(label_name.as_str()));
     let output_file = output_folder.join("test.xml");
-    std::fs::create_dir_all(output_folder).expect("Make dir failed");
-    let mut file = std::fs::File::create(&output_file)
-        .unwrap_or_else(|_| panic!("Should open file {:?}", output_file));
+    std::fs::create_dir_all(output_folder)?;
+    let mut file = std::fs::File::create(&output_file)?;
     let e = junit_xml_error_writer::TestSuites {
         testsuites: vec![junit_xml_error_writer::TestSuite {
             name: label_name,
@@ -34,7 +34,17 @@ pub fn emit_junit_xml_from_failed_operation(
             testcases: test_cases,
         }],
     };
-    use xml::writer::EventWriter;
     let mut event_writer = EventWriter::new(&mut file);
-    e.write_xml(&mut event_writer);
+
+    match e.write_xml(&mut event_writer) {
+        Ok(good) => {
+            file.flush()?;
+            Ok(good)
+        }
+        Err(e) => {
+            // we should remove the file when we fail
+            std::fs::remove_file(output_file)?;
+            return Err(e);
+        }
+    }
 }

--- a/bazelfe-core/src/config/daemon_config.rs
+++ b/bazelfe-core/src/config/daemon_config.rs
@@ -47,7 +47,7 @@ fn default_enabled() -> bool {
     false
 }
 
-fn serialize_regex<'de, S>(regexes: &NotifyRegexes, serializer: S) -> Result<S::Ok, S::Error>
+fn serialize_regex<S>(regexes: &NotifyRegexes, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: serde::Serializer,
 {

--- a/bazelfe-core/src/config/mod.rs
+++ b/bazelfe-core/src/config/mod.rs
@@ -31,7 +31,7 @@ pub async fn load_config_file(
         path = Some((*p).clone())
     };
 
-    if path == None {
+    if path.is_none() {
         if let Ok(home_dir) = std::env::var("HOME") {
             let cur_p = PathBuf::from(format!("{}/.bazelfe_config", home_dir));
             if cur_p.exists() {

--- a/bazelfe-core/src/error_extraction/mod.rs
+++ b/bazelfe-core/src/error_extraction/mod.rs
@@ -78,7 +78,7 @@ pub fn extract_errors(target_kind: &Option<String>, input: &str) -> Vec<ActionRe
         existing
     } else {
         let mut v = scala::extract_errors(input);
-        v.extend(java::extract_errors(input).into_iter());
+        v.extend(java::extract_errors(input));
         v
     }
 }

--- a/bazelfe-core/src/hydrated_stream_processors/process_bazel_failures/mod.rs
+++ b/bazelfe-core/src/hydrated_stream_processors/process_bazel_failures/mod.rs
@@ -67,21 +67,13 @@ impl Response {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct CurrentState {
     pub ignore_list: HashSet<String>,
     pub added_target_for_class: HashMap<crate::error_extraction::ActionRequest, HashSet<String>>,
     pub epoch: usize,
 }
-impl Default for CurrentState {
-    fn default() -> Self {
-        Self {
-            ignore_list: HashSet::default(),
-            added_target_for_class: HashMap::default(),
-            epoch: 0,
-        }
-    }
-}
+
 #[derive(Clone, Debug)]
 pub struct ProcessBazelFailures<T: Buildozer, U: CommandLineRunner> {
     index_table: index_table::IndexTable,
@@ -170,7 +162,7 @@ impl<T: Buildozer, U: CommandLineRunner> ProcessBazelFailures<T, U> {
 
                 let missing_dependencies_response =
                     process_missing_dependency_errors::process_missing_dependency_errors(
-                        &mut *prev_data,
+                        &mut prev_data,
                         self.buildozer.clone(),
                         action_failed_error_info,
                         &self.index_table,
@@ -205,7 +197,7 @@ impl<T: Buildozer, U: CommandLineRunner> ProcessBazelFailures<T, U> {
                     let mut prev_data = arc_resp.lock().await;
                     res.push(
                         process_build_abort_errors::apply_candidates(
-                            &mut *prev_data,
+                            &mut prev_data,
                             errors,
                             self.buildozer.clone(),
                         )
@@ -250,7 +242,7 @@ impl<T: Buildozer, U: CommandLineRunner> ProcessBazelFailures<T, U> {
                     let mut prev_data = arc_resp.lock().await;
                     res.push(
                         process_build_abort_errors::apply_candidates(
-                            &mut *prev_data,
+                            &mut prev_data,
                             errors,
                             self.buildozer.clone(),
                         )

--- a/bazelfe-core/src/hydrated_stream_processors/process_bazel_failures/process_build_abort_errors.rs
+++ b/bazelfe-core/src/hydrated_stream_processors/process_bazel_failures/process_build_abort_errors.rs
@@ -382,7 +382,7 @@ pub async fn apply_candidates<T: Buildozer + Clone + Send + Sync + 'static>(
                     dep_like, target_to_operate_on
                 );
 
-                for attr in vec![BazelAttrTarget::Deps, BazelAttrTarget::RuntimeDeps] {
+                for attr in [BazelAttrTarget::Deps, BazelAttrTarget::RuntimeDeps] {
                     if let Ok(deps_for_target) =
                         buildozer.print_attr(&attr, &target_to_operate_on).await
                     {

--- a/bazelfe-core/src/hydrated_stream_processors/process_bazel_failures/process_missing_dependency_errors.rs
+++ b/bazelfe-core/src/hydrated_stream_processors/process_bazel_failures/process_missing_dependency_errors.rs
@@ -136,7 +136,7 @@ pub fn expand_candidate_import_requests(action_requests: Vec<ActionRequest>) -> 
         }
     }
 
-    candidate_import_requests.extend(extras.into_iter());
+    candidate_import_requests.extend(extras);
 
     for y in candidate_import_requests.into_iter() {
         res_action_requests.push(ActionRequest::Prefix(y));

--- a/bazelfe-core/src/hydrated_stream_processors/process_bazel_failures/process_user_defined_actions.rs
+++ b/bazelfe-core/src/hydrated_stream_processors/process_bazel_failures/process_user_defined_actions.rs
@@ -55,7 +55,7 @@ struct CommandLineAction {
     pub why: String,
 }
 
-fn extract_configured_regexes<'a, 'b, 'c>(
+fn extract_configured_regexes<'a>(
     target_label: &'a String,
     input_error_streams: &'a Vec<String>,
     command_stream: &'a mut Vec<CommandLineAction>,

--- a/bazelfe-core/src/index_table/mod.rs
+++ b/bazelfe-core/src/index_table/mod.rs
@@ -41,7 +41,7 @@ pub struct DebugIndexTable {
     pub data_map: Vec<(String, Vec<(u16, String)>)>,
 }
 
-impl<'a> Default for IndexTable {
+impl Default for IndexTable {
     fn default() -> Self {
         Self::new()
     }
@@ -106,7 +106,7 @@ impl<'a> IndexTable {
     pub async fn set_popularity(&self, label_id: usize, popularity: u16) {
         let mut lock = self.id_to_popularity.write().await;
         if label_id >= lock.len() {
-            lock.resize_with((label_id + 100) as usize, Default::default);
+            lock.resize_with(label_id + 100, Default::default);
         }
         lock[label_id] = popularity;
     }
@@ -166,7 +166,7 @@ impl<'a> IndexTable {
         file.write_u64::<LittleEndian>(id_to_ctime.len() as u64)
             .unwrap();
         for e in id_to_ctime.iter() {
-            file.write_u64::<LittleEndian>(*e as u64).unwrap();
+            file.write_u64::<LittleEndian>(*e).unwrap();
         }
 
         let id_to_popularity = self.id_to_popularity.read().await;

--- a/bazelfe-core/src/jvm_indexer/jvm_indexer_app.rs
+++ b/bazelfe-core/src/jvm_indexer/jvm_indexer_app.rs
@@ -189,9 +189,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
     builder.init();
 
-    let target_blacklist = (&opt.blacklist_targets_from_index)
-        .clone()
-        .unwrap_or_default();
+    let target_blacklist = opt.blacklist_targets_from_index.clone().unwrap_or_default();
 
     let allowed_rule_kinds: Vec<String> = vec![
         "java_library",
@@ -286,7 +284,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let mut processed_count = 0;
         let mut remaining_chunks: Vec<Vec<RuleQuery>> = all_queries
             .chunks(query_rule_attr_batch_size)
-            .into_iter()
             .map(|e| e.to_vec())
             .collect();
         lazy_static! {
@@ -376,17 +373,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 }
                             }
 
-                            remaining_chunks.extend(
-                                current_chunk.chunks(next_chunk_len).into_iter().map(|e| {
-                                    e.to_vec()
-                                        .into_iter()
+                            remaining_chunks.extend(current_chunk.chunks(next_chunk_len).map(
+                                |e| {
+                                    e.iter()
+                                        .cloned()
                                         .filter(|e| {
                                             !must_go_solo.contains(&e.root)
                                                 && !global_banned_roots.contains(&e.root)
                                         })
                                         .collect()
-                                }),
-                            );
+                                },
+                            ));
                         }
                     }
                 } else {
@@ -499,7 +496,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut batch_idx = 0;
     let mut batch_elements = Vec::default();
     for cur in all_targets_to_use
-        .into_iter()
         .into_iter()
         .flat_map(|(_, e)| e.into_iter())
     {

--- a/bazelfe-core/src/label_utils/mod.rs
+++ b/bazelfe-core/src/label_utils/mod.rs
@@ -66,7 +66,7 @@ pub fn class_name_to_prefixes(class_name: &str, allow_all_minor_domains: bool) -
     let mut long_running_string = String::new();
     let mut result = Vec::new();
     let mut loop_cnt = 0;
-    let major_domains = vec!["com", "net", "org"];
+    let major_domains = ["com", "net", "org"];
     let mut is_major_domain_opt = None;
     class_name.split('.').for_each(|segment| {
         let is_major_domain = if let Some(v) = is_major_domain_opt {

--- a/bazelfe-core/src/source_dependencies/java/mod.rs
+++ b/bazelfe-core/src/source_dependencies/java/mod.rs
@@ -77,9 +77,8 @@ fn extract_package_from_line(ln: &str) -> Result<&str> {
 fn extract_package_from_file(file_lines: &str) -> Result<Option<&str>> {
     for ln in file_lines.lines() {
         if ln.contains("package") {
-            match extract_package_from_line(ln) {
-                Ok(pkg) => return Ok(Some(pkg)),
-                Err(_) => (),
+            if let Ok(pkg) = extract_package_from_line(ln) {
+                return Ok(Some(pkg));
             }
         }
     }

--- a/bazelfe-core/src/zip_parse/mod.rs
+++ b/bazelfe-core/src/zip_parse/mod.rs
@@ -43,7 +43,7 @@ fn transform_file_names_into_class_names(class_names: Vec<String>) -> Vec<String
                 None
             }
         })
-        .map(|e| e.replace("/$", "/").replace('$', ".").replace('/', "."))
+        .map(|e| e.replace("/$", "/").replace(['$', '/'], "."))
         .collect();
     vec.sort();
     vec.dedup();

--- a/bzl-remote-core/src/binaries/cache_server/app.rs
+++ b/bzl-remote-core/src/binaries/cache_server/app.rs
@@ -105,7 +105,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
             let layer = tower::ServiceBuilder::new()
                 // Apply our own middleware
-                .layer(GrpcErrorTraceLayer::default())
+                .layer(GrpcErrorTraceLayer)
                 .into_inner();
 
             let capabilites_service = CapabilitiesService::new();

--- a/bzl-remote-core/src/binaries/dump_cache_data/app.rs
+++ b/bzl-remote-core/src/binaries/dump_cache_data/app.rs
@@ -223,7 +223,7 @@ impl std::fmt::Debug for PackerV {
         match self {
             Self::Value(a) => a.fmt(f),
             Self::Layer(nme, v) => {
-                let mut r = f.debug_struct(&nme);
+                let mut r = f.debug_struct(nme);
                 for (k, v) in v.iter() {
                     r.field(k, v);
                 }

--- a/bzl-remote-core/src/cache_client/mod.rs
+++ b/bzl-remote-core/src/cache_client/mod.rs
@@ -132,7 +132,7 @@ impl ContentAddressableStore {
                     resource_name: if write_offset == 0 { resource_url.clone() } else { String::from("") },
                     write_offset: write_offset as i64
                 };
-                write_offset += bytes_read as usize;
+                write_offset += bytes_read;
 
                 yield buf;
                 if remaining == 0 {

--- a/bzl-remote-core/src/cache_service/bytestream_service.rs
+++ b/bzl-remote-core/src/cache_service/bytestream_service.rs
@@ -68,10 +68,10 @@ fn regex_resource_to_digest(
             },
         })
     } else {
-        return Err(tonic::Status::invalid_argument(format!(
+        Err(tonic::Status::invalid_argument(format!(
             "Invalid resource name: '{}'",
             resource_name
-        )));
+        )))
     }
 }
 

--- a/bzl-remote-core/src/storage_backend/io_helpers.rs
+++ b/bzl-remote-core/src/storage_backend/io_helpers.rs
@@ -68,9 +68,10 @@ fn compute_redirect(old_url: &str, location_uri: &str) -> Result<hyper::Uri, Sto
     if location_parts.scheme.is_none() {
         location_parts.scheme = old_parts.scheme;
     }
-    Ok(location_parts.try_into().map_err(|e| {
+
+    location_parts.try_into().map_err(|e| {
         StorageBackendError::Unknown(format!("Unable to convert parts back into uri {:#?}", e))
-    })?)
+    })
 }
 
 const MAX_REDIRECT_DEPTH: usize = 5;
@@ -111,11 +112,11 @@ async fn inner_download_file_to_cas<T: StorageBackend>(
                 }
             }
             if !res.status().is_success() {
-                return Err(StorageBackendError::Unknown(format!(
+                Err(StorageBackendError::Unknown(format!(
                     "couldn't fetch uri {}, had status {:?}",
                     url,
                     res.status()
-                )));
+                )))
             } else {
                 let r = store_body_in_cas(storage, res.body_mut()).await?;
                 Ok(RedirectOrValue::Value(r))

--- a/bzl-remote-core/src/storage_backend/local_disk_backend/content_addressable_store.rs
+++ b/bzl-remote-core/src/storage_backend/local_disk_backend/content_addressable_store.rs
@@ -96,7 +96,7 @@ impl ContentAddressableStore {
         &self,
         hash: &String,
     ) -> Result<Option<execution::Digest>, StorageBackendError> {
-        if let Some(metadata) = self.get_metadata(&hash)? {
+        if let Some(metadata) = self.get_metadata(hash)? {
             match metadata {
                 InMemoryLutTreeType::OnDisk => {
                     let metadata = self.expected_path_hash(hash).metadata().map_err(|e| {
@@ -121,7 +121,7 @@ impl ContentAddressableStore {
     }
 
     fn expected_path_hash(&self, hash: &String) -> PathBuf {
-        self.large_blob_path.join(&hash)
+        self.large_blob_path.join(hash)
     }
 
     fn expected_path(&self, digest: &execution::Digest) -> PathBuf {

--- a/bzl-remote-core/src/storage_backend/local_disk_backend/mod.rs
+++ b/bzl-remote-core/src/storage_backend/local_disk_backend/mod.rs
@@ -60,7 +60,7 @@ impl LocalDiskStorageBackend {
         digest: &execution::Digest,
         data: UploadType,
     ) -> Result<DataLocation, StorageBackendError> {
-        Ok(self.content_addressable_store.insert(digest, data).await?)
+        self.content_addressable_store.insert(digest, data).await
     }
 
     pub async fn cas_to_vec(


### PR DESCRIPTION
occasionally we see panics when trying to generate the junit xml. The junit code has a number of `expect` calls.

This pr changes the code to pass the `Result` along, aggregate all the xml writing failures, and list those at the very end.

It should only improve matters.