### PR TITLE
Bump to nix 0.28

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,7 +647,7 @@ dependencies = [
  "log",
  "mio",
  "muncher",
- "nix 0.27.1",
+ "nix 0.28.0",
  "notify",
  "once_cell",
  "openssl",
@@ -700,7 +700,6 @@ dependencies = [
  "log",
  "mio",
  "muncher",
- "nix 0.27.1",
  "nom",
  "notify",
  "once_cell",
@@ -916,6 +915,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "cipher"
@@ -2093,6 +2098,18 @@ checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
  "bitflags 2.4.1",
  "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.4.1",
+ "cfg-if",
+ "cfg_aliases",
  "libc",
 ]
 

--- a/bazelfe-bazel-wrapper/Cargo.toml
+++ b/bazelfe-bazel-wrapper/Cargo.toml
@@ -32,7 +32,7 @@ notify = { version = "6.1.1", optional = true }
 tokio-serde = { version = "0.9.0", features = ["bincode"], optional = true }
 tokio-util = { version = "0.7.11", features = ["compat"] }
 sha2 = "0.10.8"
-nix = "0.27.1"
+nix = { version = "0.28.0", features = ["signal"] }
 flume = { version = "0.11.0", optional = true }
 trim-margin = { version = "0.1.0", optional = true }
 dashmap = { version = "5.5.3", optional = true }

--- a/bazelfe-core/Cargo.toml
+++ b/bazelfe-core/Cargo.toml
@@ -79,7 +79,6 @@ notify = { version = "6.1.1", optional = true }
 tokio-serde = { version = "0.9.0", features = ["bincode"], optional = true }
 tokio-util = { version = "0.7.11", features = ["compat"] }
 sha2 = "0.10.8"
-nix = "0.27.1"
 flume = { version = "0.11.0", optional = true }
 trim-margin = { version = "0.1.0", optional = true }
 dashmap = { version = "5.5.3", optional = true }

--- a/bzl-remote-core/src/storage_backend/local_disk_backend/mod.rs
+++ b/bzl-remote-core/src/storage_backend/local_disk_backend/mod.rs
@@ -1,7 +1,6 @@
 use bazelfe_protos::build::bazel::remote::execution::v2::{self as execution};
 
 mod content_addressable_store;
-pub use content_addressable_store::ArcDynBox;
 use content_addressable_store::ContentAddressableStore;
 
 mod action_cache;


### PR DESCRIPTION
replaces #1090 

version 0.28 requires an opt in feature.